### PR TITLE
Define a quick structure for libs

### DIFF
--- a/packages/numbers/src/commands/number/list.ts
+++ b/packages/numbers/src/commands/number/list.ts
@@ -1,35 +1,37 @@
 import {Command, flags} from '@oclif/command'
+import Numbers from '../../libs/numbers'
 
 export default class List extends Command {
-  static description = 'list vonage numbers'
+  static description = 'list vonage number'
 
   static examples = [
     `$ vonage number:list
-list of numbers?
+list all numbers
 `,
   ]
 
   static flags = {
     help: flags.help({char: 'h'}),
     app: flags.boolean({char: 'n', description: 'list app numbers'}),
+    sip: flags.boolean({char: 't', description: 'list sip numbers'}),
     sms: flags.boolean({char: 's', description: 'list sms numbers'}),
     tel: flags.boolean({char: 't', description: 'list tel numbers'}),
-    sip: flags.boolean({char: 't', description: 'list sip numbers'}),
   }
 
   async run() {
     const {flags} = this.parse(List)
+    const numbers = new Numbers()
 
     if (flags.app) {
-      this.log('app list')
-    } else if (flags.sms) {
-      this.log('sms list')
-    } else if (flags.tel) {
-      this.log('tel list')
+      this.log(numbers.list('app'))
     } else if (flags.sip) {
-      this.log('sip list')
+      this.log(numbers.list('sip'))
+    } else if (flags.sms) {
+      this.log(numbers.list('sms'))
+    } else if (flags.tel) {
+      this.log(numbers.list('tel'))
     } else {
-      this.log('list all numbers')
+      this.log(numbers.list('all'))
     }
   }
 }

--- a/packages/numbers/src/libs/numbers.ts
+++ b/packages/numbers/src/libs/numbers.ts
@@ -1,0 +1,5 @@
+export default class Numbers {
+  list(type: string) {
+    return `list ${type} numbers`
+  }
+}


### PR DESCRIPTION
This is an attempt to keep the commands themselves as lightweight as possible.

I see the layers of the CLI being:

- ~Interface~ - the command itself
- **Logic** - the structure that **the library in this PR** introduces
- Output - a library inside a util package; for handling outputs of various types

Reason for plural on numbers is that Number is a reserved name. It cannot be used as a class name. So while everything else should remain singular as we discussed before, the Numbers lib will need to be plural.