### PR TITLE
fix(applications): Add req'd inputs and fix usage

### DIFF
--- a/packages/applications/src/commands/apps/link.ts
+++ b/packages/applications/src/commands/apps/link.ts
@@ -9,46 +9,28 @@ interface LinkFlags {
 export default class ApplicationsLink extends AppCommand {
     static description = 'link numbers to Vonage application'
 
-    static examples = []
+    static usage = `apps:link [APPID] --number=[NUMBER]`;
 
     static flags: OutputFlags<typeof AppCommand.flags> & LinkFlags = {
         ...AppCommand.flags,
         number: flags.string({
             description: 'Owned number to be assigned',
+            required: true
         }),
     }
 
     static args = [
-        { name: 'appId', required: false },
+        { name: 'appId', required: true },
     ]
 
     async run() {
         const flags = this.parsedFlags as OutputFlags<typeof AppCommand.flags> & LinkFlags
         const args = this.parsedArgs!
 
-        // if no args provided, present UX
-        if (!args.appId && !flags.number) {
-            // interactive mode goes here.
-        }
-
-        // check for either arg, if any missing, error out
-        if (!args.appId) {
-            this.error(new Error('Argument \'APPID\' not provided'))
-        }
-
-        // get the number details, or error if number doesn't exist
-        if (!flags.number) {
-            this.error(
-                new Error('Flag \'number\' not provided.'),
-            )
-        }
-
         const number = await this.listNumbers(flags.number)
 
         // update the number with appid, lvn, country
-        let response
-
-        response = await this.updateNumber(flags.number, number.numbers[0].country, args.appId)
+        let response = await this.updateNumber(flags.number, number.numbers[0].country, args.appId)
 
         if (response['error-code'] === '200') {
             this.log(`Number '${flags.number}' is assigned to application '${args.appId}'.`)


### PR DESCRIPTION
This PR updates the `apps:link` user inputs to required and updated `usage` to match.