### PR TITLE
call toString() for ACL parsing

### DIFF
--- a/packages/cli/src/commands/jwt/index.ts
+++ b/packages/cli/src/commands/jwt/index.ts
@@ -54,7 +54,7 @@ export default class GenerateJWT extends BaseCommand<typeof GenerateJWT.flags> {
             exp: flags.exp || Date.now() + 21600
         }
 
-        flags.acl ? claims['acl'] = JSON.parse(flags.acl) : null;
+        flags.acl ? claims['acl'] = JSON.parse(flags.acl.toString()) : null;
 
         let jwt = this.Vonage.generateJwt(private_key, claims)
 


### PR DESCRIPTION
ACL needs to be a `string` type. Checked with @garann (thanks)