### PR TITLE
refactor: update oclif core 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,10 @@
         "prettier"
     ],
     "rules": {
-        "prettier/prettier": "error",
+        "curly": [
+            "error",
+            "all"
+        ],
         "indent": [
             "error",
             4

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
                 "packages/*"
             ],
             "devDependencies": {
-                "@oclif/core": "1.16.3",
-                "@oclif/dev-cli": "1.26.10",
-                "@oclif/test": "2.1.1",
                 "@types/jest": "29.0.3",
                 "@typescript-eslint/eslint-plugin": "5.38.0",
                 "@typescript-eslint/parser": "5.38.0",
@@ -21,11 +18,8 @@
                 "eslint-config-google": "0.14.0",
                 "eslint-config-oclif": "4.0.0",
                 "eslint-config-oclif-typescript": "1.0.2",
-                "eslint-config-prettier": "8.5.0",
                 "eslint-plugin-deprecation": "1.3.2",
-                "eslint-plugin-prettier": "4.2.1",
                 "lerna": "5.5.1",
-                "prettier": "2.7.1",
                 "typescript": "4.8.3"
             },
             "engines": {
@@ -466,6 +460,17 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
@@ -692,6 +697,28 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.4.14",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
         "node_modules/@lerna/add": {
@@ -2612,45 +2639,103 @@
                 "tao": "index.js"
             }
         },
-        "node_modules/@oclif/command": {
-            "version": "1.8.16",
-            "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
-            "integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
+        "node_modules/@oclif/color": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@oclif/color/-/color-1.0.1.tgz",
+            "integrity": "sha512-qjYr+izgWdIVOroiBKqTzQgc1r5Wd9QB1J7yGM2EeelqhBARiiVLRZL45vhV4zdyTRdDkZS0EBzFwQap+nliLA==",
             "dependencies": {
-                "@oclif/config": "^1.18.2",
-                "@oclif/errors": "^1.3.5",
-                "@oclif/help": "^1.0.1",
-                "@oclif/parser": "^3.8.6",
-                "debug": "^4.1.1",
-                "semver": "^7.3.2"
+                "ansi-styles": "^4.2.1",
+                "chalk": "^4.1.0",
+                "strip-ansi": "^6.0.1",
+                "supports-color": "^8.1.1",
+                "tslib": "^2"
             },
             "engines": {
                 "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "@oclif/config": "^1"
             }
         },
-        "node_modules/@oclif/config": {
-            "version": "1.18.2",
-            "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-            "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+        "node_modules/@oclif/color/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dependencies": {
-                "@oclif/errors": "^1.3.3",
-                "@oclif/parser": "^3.8.0",
-                "debug": "^4.1.1",
-                "globby": "^11.0.1",
-                "is-wsl": "^2.1.1",
-                "tslib": "^2.0.0"
+                "color-convert": "^2.0.1"
             },
             "engines": {
-                "node": ">=8.0.0"
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@oclif/color/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@oclif/color/node_modules/chalk/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@oclif/color/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@oclif/color/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/@oclif/color/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@oclif/color/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/@oclif/core": {
-            "version": "1.16.3",
-            "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.16.3.tgz",
-            "integrity": "sha512-SWrU/eGgN5kLyuZ+TqtKz2z2HTSrgaNEwkawNj4B31VXDrPv7aULS3ntVCboAKRldX/6J+Af+70BV07Rr5c5oA==",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.19.0.tgz",
+            "integrity": "sha512-4R087E3TAG6Q9cvr+4wnlryHbciioXkZmUF/Qmc08dReoFus1BIfwtR5kUa/thNmQBw5oeGnrxnl9yA/TaxAmA==",
             "dependencies": {
                 "@oclif/linewrap": "^1.0.0",
                 "@oclif/screen": "^3.0.2",
@@ -2683,14 +2768,6 @@
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@oclif/core/node_modules/@oclif/screen": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.2.tgz",
-            "integrity": "sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ==",
-            "engines": {
-                "node": ">=12.0.0"
             }
         },
         "node_modules/@oclif/core/node_modules/ansi-styles": {
@@ -2771,225 +2848,44 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
-        "node_modules/@oclif/dev-cli": {
-            "version": "1.26.10",
-            "resolved": "https://registry.npmjs.org/@oclif/dev-cli/-/dev-cli-1.26.10.tgz",
-            "integrity": "sha512-dJ+II9rVXckzFvG+82PbfphMTnoqiHvsuAAbcHrLdZWPBnFAiDKhNYE0iHnA/knAC4VGXhogsrAJ3ERT5d5r2g==",
-            "dev": true,
-            "dependencies": {
-                "@oclif/command": "^1.8.15",
-                "@oclif/config": "^1.18.2",
-                "@oclif/errors": "^1.3.5",
-                "@oclif/plugin-help": "3.2.18",
-                "cli-ux": "5.6.7",
-                "debug": "^4.1.1",
-                "find-yarn-workspace-root": "^2.0.0",
-                "fs-extra": "^8.1",
-                "github-slugger": "^1.2.1",
-                "lodash": "^4.17.11",
-                "normalize-package-data": "^3.0.0",
-                "qqjs": "^0.3.10",
-                "tslib": "^2.0.3"
-            },
-            "bin": {
-                "oclif-dev": "bin/run"
-            },
-            "engines": {
-                "node": ">=8.10.0"
-            }
-        },
-        "node_modules/@oclif/dev-cli/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "node_modules/@oclif/dev-cli/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "dev": true,
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/@oclif/dev-cli/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
-        "node_modules/@oclif/errors": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.5.tgz",
-            "integrity": "sha512-OivucXPH/eLLlOT7FkCMoZXiaVYf8I/w1eTAM1+gKzfhALwWTusxEx7wBmW0uzvkSg/9ovWLycPaBgJbM3LOCQ==",
-            "dependencies": {
-                "clean-stack": "^3.0.0",
-                "fs-extra": "^8.1",
-                "indent-string": "^4.0.0",
-                "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/@oclif/errors/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "node_modules/@oclif/errors/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/@oclif/errors/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
-        "node_modules/@oclif/help": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@oclif/help/-/help-1.0.1.tgz",
-            "integrity": "sha512-8rsl4RHL5+vBUAKBL6PFI3mj58hjPCp2VYyXD4TAa7IMStikFfOH2gtWmqLzIlxAED2EpD0dfYwo9JJxYsH7Aw==",
-            "dependencies": {
-                "@oclif/config": "1.18.2",
-                "@oclif/errors": "1.3.5",
-                "chalk": "^4.1.2",
-                "indent-string": "^4.0.0",
-                "lodash": "^4.17.21",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "widest-line": "^3.1.0",
-                "wrap-ansi": "^6.2.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/@oclif/help/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@oclif/help/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@oclif/help/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/@oclif/help/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "node_modules/@oclif/help/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@oclif/help/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@oclif/help/node_modules/wrap-ansi": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/@oclif/linewrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
             "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw=="
         },
-        "node_modules/@oclif/parser": {
-            "version": "3.8.7",
-            "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
-            "integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
+        "node_modules/@oclif/plugin-help": {
+            "version": "5.1.15",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-5.1.15.tgz",
+            "integrity": "sha512-RfLo7vOTga/02w7jTAHFOi3m4X34Xbfyl20spg4Jq7NM6WduDaIj2auXrHW3w8OkEi4Zl/g0AvB4PIyLr+NYYw==",
             "dependencies": {
-                "@oclif/errors": "^1.3.5",
-                "@oclif/linewrap": "^1.0.0",
-                "chalk": "^4.1.0",
-                "tslib": "^2.3.1"
+                "@oclif/core": "^1.16.5"
             },
             "engines": {
-                "node": ">=8.0.0"
+                "node": ">=12.0.0"
             }
         },
-        "node_modules/@oclif/parser/node_modules/ansi-styles": {
+        "node_modules/@oclif/plugin-plugins": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-2.1.4.tgz",
+            "integrity": "sha512-qhAeBUZ+/oH7EaiR+OBe1vVLWUndTw4erqJKZqO3+JH2BEI7drt/xV1DJfn3Scn3DzC/AalOjZ4IGQpL4RH1kA==",
+            "dependencies": {
+                "@oclif/color": "^1.0.1",
+                "@oclif/core": "^1.18.0",
+                "chalk": "^4.1.2",
+                "debug": "^4.3.4",
+                "fs-extra": "^9.0",
+                "http-call": "^5.2.2",
+                "load-json-file": "^5.3.0",
+                "npm-run-path": "^4.0.1",
+                "semver": "^7.3.8",
+                "tslib": "^2.0.0",
+                "yarn": "^1.22.18"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@oclif/plugin-plugins/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
@@ -3003,7 +2899,7 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/@oclif/parser/node_modules/chalk": {
+        "node_modules/@oclif/plugin-plugins/node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
@@ -3018,7 +2914,18 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/@oclif/parser/node_modules/color-convert": {
+        "node_modules/@oclif/plugin-plugins/node_modules/chalk/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@oclif/plugin-plugins/node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
@@ -3029,12 +2936,12 @@
                 "node": ">=7.0.0"
             }
         },
-        "node_modules/@oclif/parser/node_modules/color-name": {
+        "node_modules/@oclif/plugin-plugins/node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
-        "node_modules/@oclif/parser/node_modules/has-flag": {
+        "node_modules/@oclif/plugin-plugins/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
@@ -3042,140 +2949,41 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@oclif/parser/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+        "node_modules/@oclif/plugin-plugins/node_modules/load-json-file": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+            "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
             "dependencies": {
-                "has-flag": "^4.0.0"
+                "graceful-fs": "^4.1.15",
+                "parse-json": "^4.0.0",
+                "pify": "^4.0.1",
+                "strip-bom": "^3.0.0",
+                "type-fest": "^0.3.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=6"
             }
         },
-        "node_modules/@oclif/plugin-help": {
-            "version": "3.2.18",
-            "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.18.tgz",
-            "integrity": "sha512-5n5Pkz4L0duknIvFwx2Ko9Xda3miT6RZP8bgaaK3Q/9fzVBrhi4bOM0u05/OThI6V+3NsSdxYS2o1NLcXToWDg==",
-            "dev": true,
-            "dependencies": {
-                "@oclif/command": "^1.8.14",
-                "@oclif/config": "1.18.2",
-                "@oclif/errors": "1.3.5",
-                "@oclif/help": "^1.0.0",
-                "chalk": "^4.1.2",
-                "indent-string": "^4.0.0",
-                "lodash": "^4.17.21",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "widest-line": "^3.1.0",
-                "wrap-ansi": "^6.2.0"
-            },
+        "node_modules/@oclif/plugin-plugins/node_modules/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
             "engines": {
-                "node": ">=8.0.0"
+                "node": ">=4"
             }
         },
-        "node_modules/@oclif/plugin-help/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
+        "node_modules/@oclif/plugin-plugins/node_modules/type-fest": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+            "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
             "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@oclif/plugin-help/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@oclif/plugin-help/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/@oclif/plugin-help/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/@oclif/plugin-help/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@oclif/plugin-help/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@oclif/plugin-help/node_modules/wrap-ansi": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
+                "node": ">=6"
             }
         },
         "node_modules/@oclif/screen": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz",
-            "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==",
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/@oclif/test": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.1.1.tgz",
-            "integrity": "sha512-vuBDXnXbnU073xNUqj+V4Fbrp+6Xhs1sgeWUIMj69SP9qC3pUBPfEPzIoK00ga6/WxZ+2qUgqCBAOPGz3nmTEg==",
-            "dev": true,
-            "dependencies": {
-                "@oclif/core": "^1.6.4",
-                "fancy-test": "^2.0.0"
-            },
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.2.tgz",
+            "integrity": "sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ==",
             "engines": {
                 "node": ">=12.0.0"
             }
@@ -3377,6 +3185,26 @@
             "engines": {
                 "node": ">= 10"
             }
+        },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
         },
         "node_modules/@types/chai": {
             "version": "4.3.3",
@@ -3973,7 +3801,6 @@
             "version": "8.8.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
             "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-            "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3988,6 +3815,14 @@
             "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/add-stream": {
@@ -4138,6 +3973,11 @@
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
+        },
+        "node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
         },
         "node_modules/argparse": {
             "version": "1.0.10",
@@ -4690,12 +4530,6 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true
-        },
         "node_modules/ci-info": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
@@ -4772,161 +4606,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-ux": {
-            "version": "5.6.7",
-            "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.7.tgz",
-            "integrity": "sha512-dsKAurMNyFDnO6X1TiiRNiVbL90XReLKcvIq4H777NMqXGBxBws23ag8ubCJE97vVZEgWG2eSUhsyLf63Jv8+g==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dev": true,
-            "dependencies": {
-                "@oclif/command": "^1.8.15",
-                "@oclif/errors": "^1.3.5",
-                "@oclif/linewrap": "^1.0.0",
-                "@oclif/screen": "^1.0.4",
-                "ansi-escapes": "^4.3.0",
-                "ansi-styles": "^4.2.0",
-                "cardinal": "^2.1.1",
-                "chalk": "^4.1.0",
-                "clean-stack": "^3.0.0",
-                "cli-progress": "^3.4.0",
-                "extract-stack": "^2.0.0",
-                "fs-extra": "^8.1",
-                "hyperlinker": "^1.0.0",
-                "indent-string": "^4.0.0",
-                "is-wsl": "^2.2.0",
-                "js-yaml": "^3.13.1",
-                "lodash": "^4.17.21",
-                "natural-orderby": "^2.0.1",
-                "object-treeify": "^1.1.4",
-                "password-prompt": "^1.1.2",
-                "semver": "^7.3.2",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "supports-color": "^8.1.0",
-                "supports-hyperlinks": "^2.1.0",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/cli-ux/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/cli-ux/node_modules/chalk": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-            "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/cli-ux/node_modules/chalk/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-ux/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/cli-ux/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/cli-ux/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "node_modules/cli-ux/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-ux/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-            "dev": true,
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/cli-ux/node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "node_modules/cli-ux/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4.0.0"
             }
         },
         "node_modules/cli-width": {
@@ -5113,7 +4792,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -5380,6 +5058,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -5577,6 +5260,14 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
         "node_modules/diff-sequences": {
             "version": "29.0.0",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.0.0.tgz",
@@ -5676,12 +5367,6 @@
             "integrity": "sha512-UyvEPae0wvzsyNJhVfGeFSOlUkHEze8xSIiExO5tZQ8QTr7obFiJWGk3U4e7afFOJMQJDszqU/3Pk5jtKiaSEg==",
             "dev": true
         },
-        "node_modules/emoji-regex": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
-            "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
-            "dev": true
-        },
         "node_modules/encoding": {
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
@@ -5755,7 +5440,6 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dev": true,
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
@@ -6295,18 +5979,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/eslint-config-prettier": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-            "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-            "dev": true,
-            "bin": {
-                "eslint-config-prettier": "bin/cli.js"
-            },
-            "peerDependencies": {
-                "eslint": ">=7.0.0"
-            }
-        },
         "node_modules/eslint-config-xo": {
             "version": "0.35.0",
             "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.35.0.tgz",
@@ -6487,27 +6159,6 @@
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/eslint-plugin-prettier": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-            "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
-            "dev": true,
-            "dependencies": {
-                "prettier-linter-helpers": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "eslint": ">=7.28.0",
-                "prettier": ">=2.0.0"
-            },
-            "peerDependenciesMeta": {
-                "eslint-config-prettier": {
-                    "optional": true
-                }
             }
         },
         "node_modules/eslint-plugin-unicorn": {
@@ -6997,14 +6648,6 @@
                 "node": ">=0.6.0"
             }
         },
-        "node_modules/extract-stack": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/extract-stack/-/extract-stack-2.0.0.tgz",
-            "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -7014,9 +6657,9 @@
             ]
         },
         "node_modules/fancy-test": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fancy-test/-/fancy-test-2.0.0.tgz",
-            "integrity": "sha512-SFb2D/VX9SV+wNYXO1IIh1wyxUC1GS0mYCFJOWD1ia7MPj9yE2G8jaPkw4t/pg0Sj7/YJP56OzMY4nAuJSOugQ==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/fancy-test/-/fancy-test-2.0.5.tgz",
+            "integrity": "sha512-ASPLNVkHSSIdRI/uLlK+XGhf1ul/MpRN9VE84ehXL+FOprQjXrDXX3wW1wqKvtcTTC+AW0E0RxdpJ5IEopjhQA==",
             "dev": true,
             "dependencies": {
                 "@types/chai": "*",
@@ -7036,12 +6679,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        },
-        "node_modules/fast-diff": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-            "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
-            "dev": true
         },
         "node_modules/fast-glob": {
             "version": "3.2.11",
@@ -7188,15 +6825,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/find-yarn-workspace-root": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-            "dev": true,
-            "dependencies": {
-                "micromatch": "^4.0.2"
             }
         },
         "node_modules/flat": {
@@ -7466,21 +7094,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-            "dev": true,
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/getpass": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -7581,15 +7194,6 @@
             "dev": true,
             "dependencies": {
                 "ini": "^1.3.2"
-            }
-        },
-        "node_modules/github-slugger": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
-            "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
-            "dev": true,
-            "dependencies": {
-                "emoji-regex": ">=6.0.0 <=6.1.1"
             }
         },
         "node_modules/glob": {
@@ -7778,7 +7382,6 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/http-call/-/http-call-5.3.0.tgz",
             "integrity": "sha512-ahwimsC23ICE4kPl9xTBjKB4inbRaeLyZeRunC/1Jy/Z6X8tv22MEAjK+KBOMSVLaqXPTTmd8638waVIKLGx2w==",
-            "dev": true,
             "dependencies": {
                 "content-type": "^1.0.4",
                 "debug": "^4.1.1",
@@ -8176,8 +7779,7 @@
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -8330,7 +7932,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
             "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8348,7 +7949,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
             "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8916,8 +8516,7 @@
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-            "dev": true
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -9513,6 +9112,11 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+        },
         "node_modules/make-fetch-happen": {
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
@@ -9812,12 +9416,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true
         },
         "node_modules/mkdirp-infer-owner": {
             "version": "2.0.0",
@@ -10352,7 +9950,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
             "dependencies": {
                 "path-key": "^3.0.0"
             },
@@ -11053,7 +10650,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-            "dev": true,
             "dependencies": {
                 "error-ex": "^1.3.1",
                 "json-parse-better-errors": "^1.0.1"
@@ -11182,7 +10778,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -11229,7 +10824,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
             "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -11262,33 +10856,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/prettier": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-            "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-            "dev": true,
-            "bin": {
-                "prettier": "bin-prettier.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "url": "https://github.com/prettier/prettier?sponsor=1"
-            }
-        },
-        "node_modules/prettier-linter-helpers": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-            "dev": true,
-            "dependencies": {
-                "fast-diff": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/pretty-format": {
@@ -11426,16 +10993,6 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
             "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
         },
-        "node_modules/pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dev": true,
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
         "node_modules/punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -11452,193 +11009,6 @@
             "engines": {
                 "node": ">=0.6.0",
                 "teleport": ">=0.2.0"
-            }
-        },
-        "node_modules/qqjs": {
-            "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/qqjs/-/qqjs-0.3.11.tgz",
-            "integrity": "sha512-pB2X5AduTl78J+xRSxQiEmga1jQV0j43jOPs/MTgTLApGFEOn6NgdE2dEjp7nvDtjkIOZbvFIojAiYUx6ep3zg==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^2.4.1",
-                "debug": "^4.1.1",
-                "execa": "^0.10.0",
-                "fs-extra": "^6.0.1",
-                "get-stream": "^5.1.0",
-                "glob": "^7.1.2",
-                "globby": "^10.0.1",
-                "http-call": "^5.1.2",
-                "load-json-file": "^6.2.0",
-                "pkg-dir": "^4.2.0",
-                "tar-fs": "^2.0.0",
-                "tmp": "^0.1.0",
-                "write-json-file": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/qqjs/node_modules/cross-spawn": {
-            "version": "6.0.5",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-            "dev": true,
-            "dependencies": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-            },
-            "engines": {
-                "node": ">=4.8"
-            }
-        },
-        "node_modules/qqjs/node_modules/execa": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-            "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/qqjs/node_modules/execa/node_modules/get-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/qqjs/node_modules/fs-extra": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-            "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            }
-        },
-        "node_modules/qqjs/node_modules/globby": {
-            "version": "10.0.2",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
-            "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
-            "dev": true,
-            "dependencies": {
-                "@types/glob": "^7.1.1",
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.0.3",
-                "glob": "^7.1.3",
-                "ignore": "^5.1.1",
-                "merge2": "^1.2.3",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/qqjs/node_modules/is-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/qqjs/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-            "dev": true,
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/qqjs/node_modules/npm-run-path": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/qqjs/node_modules/path-key": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/qqjs/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/qqjs/node_modules/shebang-command": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "dev": true,
-            "dependencies": {
-                "shebang-regex": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/qqjs/node_modules/shebang-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/qqjs/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
-        "node_modules/qqjs/node_modules/which": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-            "dev": true,
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "which": "bin/which"
             }
         },
         "node_modules/qs": {
@@ -12319,9 +11689,9 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "node_modules/semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -12733,15 +12103,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-eof": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -12904,18 +12265,6 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "dev": true,
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
         "node_modules/tar-stream": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -12978,30 +12327,6 @@
             "dev": true,
             "dependencies": {
                 "readable-stream": "3"
-            }
-        },
-        "node_modules/tmp": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-            "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-            "dev": true,
-            "dependencies": {
-                "rimraf": "^2.6.3"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/tmp/node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
             }
         },
         "node_modules/to-fast-properties": {
@@ -13074,6 +12399,48 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ts-node": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+            "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+            "dependencies": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
             }
         },
         "node_modules/tsconfig-paths": {
@@ -13202,7 +12569,6 @@
             "version": "4.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
             "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
-            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -13307,6 +12673,11 @@
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
+        },
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
@@ -13626,6 +12997,27 @@
                 "node": ">=10"
             }
         },
+        "node_modules/yarn": {
+            "version": "1.22.19",
+            "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.19.tgz",
+            "integrity": "sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==",
+            "hasInstallScript": true,
+            "bin": {
+                "yarn": "bin/yarn.js",
+                "yarnpkg": "bin/yarn.js"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -13643,194 +13035,40 @@
             "version": "1.2.0",
             "license": "Apache 2.0",
             "dependencies": {
-                "@oclif/command": "1.8.16",
-                "@oclif/config": "1.18.3",
-                "@oclif/core": "1.16.3",
-                "@oclif/parser": "3.8.7",
-                "@vonage/cli-utils": "^1.3.0",
-                "chalk": "5.0.1",
-                "cli-ux": "5.6.3",
+                "@oclif/core": "1.19.0",
+                "@vonage/cli-utils": "1.3.0",
+                "chalk": "5.1.2",
                 "filenamify": "5.1.1",
                 "lodash": "4.17.21",
                 "prompts": "2.4.2",
                 "unique-names-generator": "4.7.1"
             },
             "devDependencies": {
-                "@oclif/test": "^2.1.1"
+                "@oclif/test": "^2.2.4"
+            }
+        },
+        "packages/applications/node_modules/@oclif/test": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.2.4.tgz",
+            "integrity": "sha512-bLaapIKHWyeuWCbD64uUCJCH+OJHFlEi6u/3sRPgi00kEyP95mM23IvkggDWEzQNh92IFj1xx5Bg8qnp0E2tjw==",
+            "dev": true,
+            "dependencies": {
+                "@oclif/core": "^1.18.0",
+                "fancy-test": "^2.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
             }
         },
-        "packages/applications/node_modules/@oclif/config": {
-            "version": "1.18.3",
-            "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-            "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
-            "dependencies": {
-                "@oclif/errors": "^1.3.5",
-                "@oclif/parser": "^3.8.0",
-                "debug": "^4.1.1",
-                "globby": "^11.0.1",
-                "is-wsl": "^2.1.1",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "packages/applications/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "packages/applications/node_modules/chalk": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-            "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
+            "integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ==",
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "packages/applications/node_modules/cli-ux": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.3.tgz",
-            "integrity": "sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dependencies": {
-                "@oclif/command": "^1.6.0",
-                "@oclif/errors": "^1.2.1",
-                "@oclif/linewrap": "^1.0.0",
-                "@oclif/screen": "^1.0.3",
-                "ansi-escapes": "^4.3.0",
-                "ansi-styles": "^4.2.0",
-                "cardinal": "^2.1.1",
-                "chalk": "^4.1.0",
-                "clean-stack": "^3.0.0",
-                "cli-progress": "^3.4.0",
-                "extract-stack": "^2.0.0",
-                "fs-extra": "^8.1",
-                "hyperlinker": "^1.0.0",
-                "indent-string": "^4.0.0",
-                "is-wsl": "^2.2.0",
-                "js-yaml": "^3.13.1",
-                "lodash": "^4.17.11",
-                "natural-orderby": "^2.0.1",
-                "object-treeify": "^1.1.4",
-                "password-prompt": "^1.1.2",
-                "semver": "^7.3.2",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "supports-color": "^8.1.0",
-                "supports-hyperlinks": "^2.1.0",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "packages/applications/node_modules/cli-ux/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "packages/applications/node_modules/cli-ux/node_modules/chalk/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "packages/applications/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "packages/applications/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "packages/applications/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "packages/applications/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "packages/applications/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "packages/applications/node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "packages/applications/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "engines": {
-                "node": ">= 4.0.0"
             }
         },
         "packages/cli": {
@@ -13844,79 +13082,66 @@
             ],
             "license": "Apache 2.0",
             "dependencies": {
-                "@oclif/command": "1.8.16",
-                "@oclif/config": "1.18.3",
-                "@oclif/core": "1.16.3",
-                "@oclif/parser": "^3.8.7",
+                "@oclif/core": "1.16.4",
+                "@oclif/plugin-help": "5.1.15",
+                "@oclif/plugin-plugins": "2.1.4",
                 "@types/node": "18.7.18",
                 "@types/shelljs": "0.8.11",
-                "@vonage/cli-utils": "^1.3.0",
-                "cli-ux": "5.6.3",
-                "filenamify": "^5.1.1",
+                "@vonage/cli-plugin-applications": "^1.2.0",
+                "@vonage/cli-plugin-numberinsight": "^1.2.0",
+                "@vonage/cli-plugin-sms": "^1.2.0",
+                "@vonage/cli-plugin-users": "^1.2.0",
+                "@vonage/cli-utils": "1.3.0",
                 "lodash": "4.17.21",
-                "shelljs": "0.8.5"
+                "shelljs": "0.8.5",
+                "ts-node": "10.9.1"
             },
             "bin": {
                 "vonage": "bin/run"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "packages/cli/node_modules/@oclif/config": {
-            "version": "1.18.3",
-            "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-            "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
+        "packages/cli/node_modules/@oclif/core": {
+            "version": "1.16.4",
+            "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.16.4.tgz",
+            "integrity": "sha512-l+xHtVMteJWeTZZ+f2yLyNjf69X0mhAH8GILXnmoAGAemXbc1DVstvloxOouarvm9xyHHhquzO1Qg5l6xa1VIw==",
             "dependencies": {
-                "@oclif/errors": "^1.3.5",
-                "@oclif/parser": "^3.8.0",
-                "debug": "^4.1.1",
-                "globby": "^11.0.1",
-                "is-wsl": "^2.1.1",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "packages/cli/node_modules/cli-ux": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.3.tgz",
-            "integrity": "sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dependencies": {
-                "@oclif/command": "^1.6.0",
-                "@oclif/errors": "^1.2.1",
                 "@oclif/linewrap": "^1.0.0",
-                "@oclif/screen": "^1.0.3",
-                "ansi-escapes": "^4.3.0",
-                "ansi-styles": "^4.2.0",
+                "@oclif/screen": "^3.0.2",
+                "ansi-escapes": "^4.3.2",
+                "ansi-styles": "^4.3.0",
                 "cardinal": "^2.1.1",
-                "chalk": "^4.1.0",
-                "clean-stack": "^3.0.0",
-                "cli-progress": "^3.4.0",
-                "extract-stack": "^2.0.0",
-                "fs-extra": "^8.1",
+                "chalk": "^4.1.2",
+                "clean-stack": "^3.0.1",
+                "cli-progress": "^3.10.0",
+                "debug": "^4.3.4",
+                "ejs": "^3.1.6",
+                "fs-extra": "^9.1.0",
+                "get-package-type": "^0.1.0",
+                "globby": "^11.1.0",
                 "hyperlinker": "^1.0.0",
                 "indent-string": "^4.0.0",
                 "is-wsl": "^2.2.0",
-                "js-yaml": "^3.13.1",
-                "lodash": "^4.17.11",
-                "natural-orderby": "^2.0.1",
-                "object-treeify": "^1.1.4",
+                "js-yaml": "^3.14.1",
+                "natural-orderby": "^2.0.3",
+                "object-treeify": "^1.1.33",
                 "password-prompt": "^1.1.2",
-                "semver": "^7.3.2",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "supports-color": "^8.1.0",
-                "supports-hyperlinks": "^2.1.0",
-                "tslib": "^2.0.0"
+                "semver": "^7.3.7",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
+                "supports-color": "^8.1.1",
+                "supports-hyperlinks": "^2.2.0",
+                "tslib": "^2.3.1",
+                "widest-line": "^3.1.0",
+                "wrap-ansi": "^7.0.0"
             },
             "engines": {
-                "node": ">=8.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "packages/cli/node_modules/cli-ux/node_modules/ansi-styles": {
+        "packages/cli/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
@@ -13930,7 +13155,7 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "packages/cli/node_modules/cli-ux/node_modules/chalk": {
+        "packages/cli/node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
@@ -13945,7 +13170,7 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "packages/cli/node_modules/cli-ux/node_modules/chalk/node_modules/supports-color": {
+        "packages/cli/node_modules/chalk/node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -13972,33 +13197,12 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
-        "packages/cli/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
         "packages/cli/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "packages/cli/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
             }
         },
         "packages/cli/node_modules/supports-color": {
@@ -14015,207 +13219,45 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
-        "packages/cli/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
         "packages/conversations": {
             "name": "@vonage/cli-plugin-conversations",
             "version": "1.0.0-beta.17",
             "license": "MIT",
             "dependencies": {
-                "@oclif/command": "1.8.16",
-                "@oclif/config": "1.18.3",
-                "@oclif/core": "1.16.3",
-                "@oclif/parser": "3.8.7",
-                "@vonage/cli-utils": "^1.3.0",
+                "@oclif/core": "1.19.0",
+                "@vonage/cli-utils": "1.3.0",
                 "@vonage/jwt": "3.0.0-beta.1",
                 "@vonage/vetch": "3.0.0-beta.3",
-                "chalk": "5.0.1",
-                "cli-ux": "5.6.3",
-                "lodash": "^4.17.21"
+                "chalk": "5.1.2",
+                "lodash": "4.17.21"
             },
             "devDependencies": {
-                "@oclif/test": "^2.1.1",
+                "@oclif/test": "^2.2.4",
                 "nock": "^13.2.9"
+            }
+        },
+        "packages/conversations/node_modules/@oclif/test": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.2.4.tgz",
+            "integrity": "sha512-bLaapIKHWyeuWCbD64uUCJCH+OJHFlEi6u/3sRPgi00kEyP95mM23IvkggDWEzQNh92IFj1xx5Bg8qnp0E2tjw==",
+            "dev": true,
+            "dependencies": {
+                "@oclif/core": "^1.18.0",
+                "fancy-test": "^2.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
             }
         },
-        "packages/conversations/node_modules/@oclif/config": {
-            "version": "1.18.3",
-            "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-            "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
-            "dependencies": {
-                "@oclif/errors": "^1.3.5",
-                "@oclif/parser": "^3.8.0",
-                "debug": "^4.1.1",
-                "globby": "^11.0.1",
-                "is-wsl": "^2.1.1",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "packages/conversations/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "packages/conversations/node_modules/chalk": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-            "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
+            "integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ==",
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "packages/conversations/node_modules/cli-ux": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.3.tgz",
-            "integrity": "sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dependencies": {
-                "@oclif/command": "^1.6.0",
-                "@oclif/errors": "^1.2.1",
-                "@oclif/linewrap": "^1.0.0",
-                "@oclif/screen": "^1.0.3",
-                "ansi-escapes": "^4.3.0",
-                "ansi-styles": "^4.2.0",
-                "cardinal": "^2.1.1",
-                "chalk": "^4.1.0",
-                "clean-stack": "^3.0.0",
-                "cli-progress": "^3.4.0",
-                "extract-stack": "^2.0.0",
-                "fs-extra": "^8.1",
-                "hyperlinker": "^1.0.0",
-                "indent-string": "^4.0.0",
-                "is-wsl": "^2.2.0",
-                "js-yaml": "^3.13.1",
-                "lodash": "^4.17.11",
-                "natural-orderby": "^2.0.1",
-                "object-treeify": "^1.1.4",
-                "password-prompt": "^1.1.2",
-                "semver": "^7.3.2",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "supports-color": "^8.1.0",
-                "supports-hyperlinks": "^2.1.0",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "packages/conversations/node_modules/cli-ux/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "packages/conversations/node_modules/cli-ux/node_modules/chalk/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "packages/conversations/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "packages/conversations/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "packages/conversations/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "packages/conversations/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "packages/conversations/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "packages/conversations/node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "packages/conversations/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "engines": {
-                "node": ">= 4.0.0"
             }
         },
         "packages/numberInsight": {
@@ -14223,36 +13265,17 @@
             "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
-                "@oclif/core": "^1.16.3",
-                "@oclif/parser": "3.8.7",
+                "@oclif/core": "^1.19.0",
                 "@vonage/cli-utils": "^1.3.0",
-                "chalk": "5.0.1",
-                "cli-ux": "5.6.3",
+                "chalk": "5.1.2",
                 "lodash": "4.17.21",
                 "prompts": "^2.4.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "packages/numberInsight/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "packages/numberInsight/node_modules/chalk": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-            "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
+            "integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ==",
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -14260,314 +13283,30 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "packages/numberInsight/node_modules/cli-ux": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.3.tgz",
-            "integrity": "sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dependencies": {
-                "@oclif/command": "^1.6.0",
-                "@oclif/errors": "^1.2.1",
-                "@oclif/linewrap": "^1.0.0",
-                "@oclif/screen": "^1.0.3",
-                "ansi-escapes": "^4.3.0",
-                "ansi-styles": "^4.2.0",
-                "cardinal": "^2.1.1",
-                "chalk": "^4.1.0",
-                "clean-stack": "^3.0.0",
-                "cli-progress": "^3.4.0",
-                "extract-stack": "^2.0.0",
-                "fs-extra": "^8.1",
-                "hyperlinker": "^1.0.0",
-                "indent-string": "^4.0.0",
-                "is-wsl": "^2.2.0",
-                "js-yaml": "^3.13.1",
-                "lodash": "^4.17.11",
-                "natural-orderby": "^2.0.1",
-                "object-treeify": "^1.1.4",
-                "password-prompt": "^1.1.2",
-                "semver": "^7.3.2",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "supports-color": "^8.1.0",
-                "supports-hyperlinks": "^2.1.0",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "packages/numberInsight/node_modules/cli-ux/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "packages/numberInsight/node_modules/cli-ux/node_modules/chalk/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "packages/numberInsight/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "packages/numberInsight/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "packages/numberInsight/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "packages/numberInsight/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "packages/numberInsight/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "packages/numberInsight/node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "packages/numberInsight/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
         "packages/numbers": {
             "name": "@vonage/cli-plugin-numbers",
             "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
-                "@oclif/command": "1.8.16",
-                "@oclif/config": "1.18.3",
-                "@oclif/core": "1.16.3",
-                "@oclif/parser": "3.8.7",
-                "@vonage/cli-utils": "^1.3.0",
-                "cli-ux": "5.6.3"
+                "@oclif/core": "1.19.0",
+                "@vonage/cli-utils": "1.3.0"
             },
             "devDependencies": {
-                "@oclif/test": "^2.1.1",
+                "@oclif/test": "^2.2.4",
                 "nock": "^13.2.9"
+            }
+        },
+        "packages/numbers/node_modules/@oclif/test": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.2.4.tgz",
+            "integrity": "sha512-bLaapIKHWyeuWCbD64uUCJCH+OJHFlEi6u/3sRPgi00kEyP95mM23IvkggDWEzQNh92IFj1xx5Bg8qnp0E2tjw==",
+            "dev": true,
+            "dependencies": {
+                "@oclif/core": "^1.18.0",
+                "fancy-test": "^2.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
-            }
-        },
-        "packages/numbers/node_modules/@oclif/config": {
-            "version": "1.18.3",
-            "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-            "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
-            "dependencies": {
-                "@oclif/errors": "^1.3.5",
-                "@oclif/parser": "^3.8.0",
-                "debug": "^4.1.1",
-                "globby": "^11.0.1",
-                "is-wsl": "^2.1.1",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "packages/numbers/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "packages/numbers/node_modules/cli-ux": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.3.tgz",
-            "integrity": "sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dependencies": {
-                "@oclif/command": "^1.6.0",
-                "@oclif/errors": "^1.2.1",
-                "@oclif/linewrap": "^1.0.0",
-                "@oclif/screen": "^1.0.3",
-                "ansi-escapes": "^4.3.0",
-                "ansi-styles": "^4.2.0",
-                "cardinal": "^2.1.1",
-                "chalk": "^4.1.0",
-                "clean-stack": "^3.0.0",
-                "cli-progress": "^3.4.0",
-                "extract-stack": "^2.0.0",
-                "fs-extra": "^8.1",
-                "hyperlinker": "^1.0.0",
-                "indent-string": "^4.0.0",
-                "is-wsl": "^2.2.0",
-                "js-yaml": "^3.13.1",
-                "lodash": "^4.17.11",
-                "natural-orderby": "^2.0.1",
-                "object-treeify": "^1.1.4",
-                "password-prompt": "^1.1.2",
-                "semver": "^7.3.2",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "supports-color": "^8.1.0",
-                "supports-hyperlinks": "^2.1.0",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "packages/numbers/node_modules/cli-ux/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "packages/numbers/node_modules/cli-ux/node_modules/chalk/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "packages/numbers/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "packages/numbers/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "packages/numbers/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "packages/numbers/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "packages/numbers/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "packages/numbers/node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "packages/numbers/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "engines": {
-                "node": ">= 4.0.0"
             }
         },
         "packages/sms": {
@@ -14575,13 +13314,22 @@
             "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
-                "@oclif/parser": "3.8.7",
                 "@vonage/cli-utils": "^1.3.0",
                 "@vonage/vetch": "3.0.0-beta.3"
             },
             "devDependencies": {
-                "@oclif/test": "^2.1.1",
+                "@oclif/test": "^2.2.4",
                 "nock": "^13.2.9"
+            }
+        },
+        "packages/sms/node_modules/@oclif/test": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.2.4.tgz",
+            "integrity": "sha512-bLaapIKHWyeuWCbD64uUCJCH+OJHFlEi6u/3sRPgi00kEyP95mM23IvkggDWEzQNh92IFj1xx5Bg8qnp0E2tjw==",
+            "dev": true,
+            "dependencies": {
+                "@oclif/core": "^1.18.0",
+                "fancy-test": "^2.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -14592,38 +13340,28 @@
             "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
-                "@oclif/command": "1.8.16",
-                "@oclif/config": "1.18.3",
-                "@oclif/core": "1.16.3",
-                "@oclif/parser": "3.8.7",
+                "@oclif/core": "1.19.0",
                 "@vonage/cli-utils": "^1.3.0",
                 "@vonage/jwt": "3.0.0-beta.0",
                 "@vonage/vetch": "3.0.0-beta.0",
-                "chalk": "5.0.1",
-                "cli-ux": "5.6.3",
+                "chalk": "5.1.2",
                 "lodash": "4.17.21"
             },
             "devDependencies": {
-                "@oclif/test": "^2.1.1"
+                "@oclif/test": "^2.2.4"
+            }
+        },
+        "packages/users/node_modules/@oclif/test": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.2.4.tgz",
+            "integrity": "sha512-bLaapIKHWyeuWCbD64uUCJCH+OJHFlEi6u/3sRPgi00kEyP95mM23IvkggDWEzQNh92IFj1xx5Bg8qnp0E2tjw==",
+            "dev": true,
+            "dependencies": {
+                "@oclif/core": "^1.18.0",
+                "fancy-test": "^2.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
-            }
-        },
-        "packages/users/node_modules/@oclif/config": {
-            "version": "1.18.3",
-            "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-            "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
-            "dependencies": {
-                "@oclif/errors": "^1.3.5",
-                "@oclif/parser": "^3.8.0",
-                "debug": "^4.1.1",
-                "globby": "^11.0.1",
-                "is-wsl": "^2.1.1",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
             }
         },
         "packages/users/node_modules/@vonage/jwt": {
@@ -14644,24 +13382,10 @@
                 "node-fetch": "^2.6.1"
             }
         },
-        "packages/users/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "packages/users/node_modules/chalk": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-            "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
+            "integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ==",
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -14669,166 +13393,20 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "packages/users/node_modules/cli-ux": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.3.tgz",
-            "integrity": "sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dependencies": {
-                "@oclif/command": "^1.6.0",
-                "@oclif/errors": "^1.2.1",
-                "@oclif/linewrap": "^1.0.0",
-                "@oclif/screen": "^1.0.3",
-                "ansi-escapes": "^4.3.0",
-                "ansi-styles": "^4.2.0",
-                "cardinal": "^2.1.1",
-                "chalk": "^4.1.0",
-                "clean-stack": "^3.0.0",
-                "cli-progress": "^3.4.0",
-                "extract-stack": "^2.0.0",
-                "fs-extra": "^8.1",
-                "hyperlinker": "^1.0.0",
-                "indent-string": "^4.0.0",
-                "is-wsl": "^2.2.0",
-                "js-yaml": "^3.13.1",
-                "lodash": "^4.17.11",
-                "natural-orderby": "^2.0.1",
-                "object-treeify": "^1.1.4",
-                "password-prompt": "^1.1.2",
-                "semver": "^7.3.2",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "supports-color": "^8.1.0",
-                "supports-hyperlinks": "^2.1.0",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "packages/users/node_modules/cli-ux/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "packages/users/node_modules/cli-ux/node_modules/chalk/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "packages/users/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "packages/users/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "packages/users/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "packages/users/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "packages/users/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "packages/users/node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "packages/users/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
         "packages/utils": {
             "name": "@vonage/cli-utils",
             "version": "1.3.0",
             "license": "MIT",
             "dependencies": {
-                "@oclif/command": "1.8.16",
-                "@oclif/config": "1.18.3",
-                "@oclif/core": "1.16.3",
-                "@types/node": "18.7.18",
+                "@oclif/core": "^1.19.0",
+                "@types/node": "18.11.0",
                 "@vonage/server-sdk": "2.11.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
             }
         },
-        "packages/utils/node_modules/@oclif/config": {
-            "version": "1.18.3",
-            "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-            "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
-            "dependencies": {
-                "@oclif/errors": "^1.3.5",
-                "@oclif/parser": "^3.8.0",
-                "debug": "^4.1.1",
-                "globby": "^11.0.1",
-                "is-wsl": "^2.1.1",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
+        "packages/utils/node_modules/@types/node": {
+            "version": "18.11.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
+            "integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w=="
         }
     },
     "dependencies": {
@@ -15165,6 +13743,14 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "requires": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            }
+        },
         "@eslint/eslintrc": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
@@ -15336,6 +13922,25 @@
                         "has-flag": "^4.0.0"
                     }
                 }
+            }
+        },
+        "@jridgewell/resolve-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+        },
+        "@jridgewell/sourcemap-codec": {
+            "version": "1.4.14",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+        },
+        "@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "requires": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
         "@lerna/add": {
@@ -16854,72 +15459,18 @@
                 "nx": "14.7.6"
             }
         },
-        "@oclif/command": {
-            "version": "1.8.16",
-            "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
-            "integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
+        "@oclif/color": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@oclif/color/-/color-1.0.1.tgz",
+            "integrity": "sha512-qjYr+izgWdIVOroiBKqTzQgc1r5Wd9QB1J7yGM2EeelqhBARiiVLRZL45vhV4zdyTRdDkZS0EBzFwQap+nliLA==",
             "requires": {
-                "@oclif/config": "^1.18.2",
-                "@oclif/errors": "^1.3.5",
-                "@oclif/help": "^1.0.1",
-                "@oclif/parser": "^3.8.6",
-                "debug": "^4.1.1",
-                "semver": "^7.3.2"
-            }
-        },
-        "@oclif/config": {
-            "version": "1.18.2",
-            "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-            "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
-            "requires": {
-                "@oclif/errors": "^1.3.3",
-                "@oclif/parser": "^3.8.0",
-                "debug": "^4.1.1",
-                "globby": "^11.0.1",
-                "is-wsl": "^2.1.1",
-                "tslib": "^2.0.0"
-            }
-        },
-        "@oclif/core": {
-            "version": "1.16.3",
-            "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.16.3.tgz",
-            "integrity": "sha512-SWrU/eGgN5kLyuZ+TqtKz2z2HTSrgaNEwkawNj4B31VXDrPv7aULS3ntVCboAKRldX/6J+Af+70BV07Rr5c5oA==",
-            "requires": {
-                "@oclif/linewrap": "^1.0.0",
-                "@oclif/screen": "^3.0.2",
-                "ansi-escapes": "^4.3.2",
-                "ansi-styles": "^4.3.0",
-                "cardinal": "^2.1.1",
-                "chalk": "^4.1.2",
-                "clean-stack": "^3.0.1",
-                "cli-progress": "^3.10.0",
-                "debug": "^4.3.4",
-                "ejs": "^3.1.6",
-                "fs-extra": "^9.1.0",
-                "get-package-type": "^0.1.0",
-                "globby": "^11.1.0",
-                "hyperlinker": "^1.0.0",
-                "indent-string": "^4.0.0",
-                "is-wsl": "^2.2.0",
-                "js-yaml": "^3.14.1",
-                "natural-orderby": "^2.0.3",
-                "object-treeify": "^1.1.33",
-                "password-prompt": "^1.1.2",
-                "semver": "^7.3.7",
-                "string-width": "^4.2.3",
+                "ansi-styles": "^4.2.1",
+                "chalk": "^4.1.0",
                 "strip-ansi": "^6.0.1",
                 "supports-color": "^8.1.1",
-                "supports-hyperlinks": "^2.2.0",
-                "tslib": "^2.3.1",
-                "widest-line": "^3.1.0",
-                "wrap-ansi": "^7.0.0"
+                "tslib": "^2"
             },
             "dependencies": {
-                "@oclif/screen": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.2.tgz",
-                    "integrity": "sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ=="
-                },
                 "ansi-styles": {
                     "version": "4.3.0",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -16975,106 +15526,39 @@
                 }
             }
         },
-        "@oclif/dev-cli": {
-            "version": "1.26.10",
-            "resolved": "https://registry.npmjs.org/@oclif/dev-cli/-/dev-cli-1.26.10.tgz",
-            "integrity": "sha512-dJ+II9rVXckzFvG+82PbfphMTnoqiHvsuAAbcHrLdZWPBnFAiDKhNYE0iHnA/knAC4VGXhogsrAJ3ERT5d5r2g==",
-            "dev": true,
+        "@oclif/core": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.19.0.tgz",
+            "integrity": "sha512-4R087E3TAG6Q9cvr+4wnlryHbciioXkZmUF/Qmc08dReoFus1BIfwtR5kUa/thNmQBw5oeGnrxnl9yA/TaxAmA==",
             "requires": {
-                "@oclif/command": "^1.8.15",
-                "@oclif/config": "^1.18.2",
-                "@oclif/errors": "^1.3.5",
-                "@oclif/plugin-help": "3.2.18",
-                "cli-ux": "5.6.7",
-                "debug": "^4.1.1",
-                "find-yarn-workspace-root": "^2.0.0",
-                "fs-extra": "^8.1",
-                "github-slugger": "^1.2.1",
-                "lodash": "^4.17.11",
-                "normalize-package-data": "^3.0.0",
-                "qqjs": "^0.3.10",
-                "tslib": "^2.0.3"
-            },
-            "dependencies": {
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-                    "dev": true
-                }
-            }
-        },
-        "@oclif/errors": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.5.tgz",
-            "integrity": "sha512-OivucXPH/eLLlOT7FkCMoZXiaVYf8I/w1eTAM1+gKzfhALwWTusxEx7wBmW0uzvkSg/9ovWLycPaBgJbM3LOCQ==",
-            "requires": {
-                "clean-stack": "^3.0.0",
-                "fs-extra": "^8.1",
-                "indent-string": "^4.0.0",
-                "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^7.0.0"
-            },
-            "dependencies": {
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-                }
-            }
-        },
-        "@oclif/help": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@oclif/help/-/help-1.0.1.tgz",
-            "integrity": "sha512-8rsl4RHL5+vBUAKBL6PFI3mj58hjPCp2VYyXD4TAa7IMStikFfOH2gtWmqLzIlxAED2EpD0dfYwo9JJxYsH7Aw==",
-            "requires": {
-                "@oclif/config": "1.18.2",
-                "@oclif/errors": "1.3.5",
+                "@oclif/linewrap": "^1.0.0",
+                "@oclif/screen": "^3.0.2",
+                "ansi-escapes": "^4.3.2",
+                "ansi-styles": "^4.3.0",
+                "cardinal": "^2.1.1",
                 "chalk": "^4.1.2",
+                "clean-stack": "^3.0.1",
+                "cli-progress": "^3.10.0",
+                "debug": "^4.3.4",
+                "ejs": "^3.1.6",
+                "fs-extra": "^9.1.0",
+                "get-package-type": "^0.1.0",
+                "globby": "^11.1.0",
+                "hyperlinker": "^1.0.0",
                 "indent-string": "^4.0.0",
-                "lodash": "^4.17.21",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
+                "is-wsl": "^2.2.0",
+                "js-yaml": "^3.14.1",
+                "natural-orderby": "^2.0.3",
+                "object-treeify": "^1.1.33",
+                "password-prompt": "^1.1.2",
+                "semver": "^7.3.7",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
+                "supports-color": "^8.1.1",
+                "supports-hyperlinks": "^2.2.0",
+                "tslib": "^2.3.1",
                 "widest-line": "^3.1.0",
-                "wrap-ansi": "^6.2.0"
+                "wrap-ansi": "^7.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -17092,6 +15576,16 @@
                     "requires": {
                         "ansi-styles": "^4.1.0",
                         "supports-color": "^7.1.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "7.2.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                            "requires": {
+                                "has-flag": "^4.0.0"
+                            }
+                        }
                     }
                 },
                 "color-convert": {
@@ -17113,21 +15607,11 @@
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
                 },
                 "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "version": "8.1.1",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
                     "requires": {
                         "has-flag": "^4.0.0"
-                    }
-                },
-                "wrap-ansi": {
-                    "version": "6.2.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-                    "requires": {
-                        "ansi-styles": "^4.0.0",
-                        "string-width": "^4.1.0",
-                        "strip-ansi": "^6.0.0"
                     }
                 }
             }
@@ -17137,15 +15621,30 @@
             "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
             "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw=="
         },
-        "@oclif/parser": {
-            "version": "3.8.7",
-            "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
-            "integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
+        "@oclif/plugin-help": {
+            "version": "5.1.15",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-5.1.15.tgz",
+            "integrity": "sha512-RfLo7vOTga/02w7jTAHFOi3m4X34Xbfyl20spg4Jq7NM6WduDaIj2auXrHW3w8OkEi4Zl/g0AvB4PIyLr+NYYw==",
             "requires": {
-                "@oclif/errors": "^1.3.5",
-                "@oclif/linewrap": "^1.0.0",
-                "chalk": "^4.1.0",
-                "tslib": "^2.3.1"
+                "@oclif/core": "^1.16.5"
+            }
+        },
+        "@oclif/plugin-plugins": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-2.1.4.tgz",
+            "integrity": "sha512-qhAeBUZ+/oH7EaiR+OBe1vVLWUndTw4erqJKZqO3+JH2BEI7drt/xV1DJfn3Scn3DzC/AalOjZ4IGQpL4RH1kA==",
+            "requires": {
+                "@oclif/color": "^1.0.1",
+                "@oclif/core": "^1.18.0",
+                "chalk": "^4.1.2",
+                "debug": "^4.3.4",
+                "fs-extra": "^9.0",
+                "http-call": "^5.2.2",
+                "load-json-file": "^5.3.0",
+                "npm-run-path": "^4.0.1",
+                "semver": "^7.3.8",
+                "tslib": "^2.0.0",
+                "yarn": "^1.22.18"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -17163,6 +15662,16 @@
                     "requires": {
                         "ansi-styles": "^4.1.0",
                         "supports-color": "^7.1.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "7.2.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                            "requires": {
+                                "has-flag": "^4.0.0"
+                            }
+                        }
                     }
                 },
                 "color-convert": {
@@ -17183,111 +15692,34 @@
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
                 },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                "load-json-file": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+                    "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
                     "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
-            }
-        },
-        "@oclif/plugin-help": {
-            "version": "3.2.18",
-            "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.18.tgz",
-            "integrity": "sha512-5n5Pkz4L0duknIvFwx2Ko9Xda3miT6RZP8bgaaK3Q/9fzVBrhi4bOM0u05/OThI6V+3NsSdxYS2o1NLcXToWDg==",
-            "dev": true,
-            "requires": {
-                "@oclif/command": "^1.8.14",
-                "@oclif/config": "1.18.2",
-                "@oclif/errors": "1.3.5",
-                "@oclif/help": "^1.0.0",
-                "chalk": "^4.1.2",
-                "indent-string": "^4.0.0",
-                "lodash": "^4.17.21",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "widest-line": "^3.1.0",
-                "wrap-ansi": "^6.2.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
+                        "graceful-fs": "^4.1.15",
+                        "parse-json": "^4.0.0",
+                        "pify": "^4.0.1",
+                        "strip-bom": "^3.0.0",
+                        "type-fest": "^0.3.0"
                     }
                 },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
                 },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                },
-                "wrap-ansi": {
-                    "version": "6.2.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.0.0",
-                        "string-width": "^4.1.0",
-                        "strip-ansi": "^6.0.0"
-                    }
+                "type-fest": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+                    "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
                 }
             }
         },
         "@oclif/screen": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz",
-            "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw=="
-        },
-        "@oclif/test": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.1.1.tgz",
-            "integrity": "sha512-vuBDXnXbnU073xNUqj+V4Fbrp+6Xhs1sgeWUIMj69SP9qC3pUBPfEPzIoK00ga6/WxZ+2qUgqCBAOPGz3nmTEg==",
-            "dev": true,
-            "requires": {
-                "@oclif/core": "^1.6.4",
-                "fancy-test": "^2.0.0"
-            }
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.2.tgz",
+            "integrity": "sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ=="
         },
         "@octokit/auth-token": {
             "version": "3.0.1",
@@ -17440,6 +15872,26 @@
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
             "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
             "dev": true
+        },
+        "@tsconfig/node10": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+        },
+        "@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+        },
+        "@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+        },
+        "@tsconfig/node16": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
         },
         "@types/chai": {
             "version": "4.3.3",
@@ -17802,90 +16254,79 @@
         "@vonage/cli": {
             "version": "file:packages/cli",
             "requires": {
-                "@oclif/command": "1.8.16",
-                "@oclif/config": "1.18.3",
-                "@oclif/core": "1.16.3",
-                "@oclif/parser": "^3.8.7",
+                "@oclif/core": "1.16.4",
+                "@oclif/plugin-help": "5.1.15",
+                "@oclif/plugin-plugins": "2.1.4",
                 "@types/node": "18.7.18",
                 "@types/shelljs": "0.8.11",
-                "@vonage/cli-utils": "^1.3.0",
-                "cli-ux": "5.6.3",
-                "filenamify": "^5.1.1",
+                "@vonage/cli-plugin-applications": "^1.2.0",
+                "@vonage/cli-plugin-numberinsight": "^1.2.0",
+                "@vonage/cli-plugin-sms": "^1.2.0",
+                "@vonage/cli-plugin-users": "^1.2.0",
+                "@vonage/cli-utils": "1.3.0",
                 "lodash": "4.17.21",
-                "shelljs": "0.8.5"
+                "shelljs": "0.8.5",
+                "ts-node": "10.9.1"
             },
             "dependencies": {
-                "@oclif/config": {
-                    "version": "1.18.3",
-                    "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-                    "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
+                "@oclif/core": {
+                    "version": "1.16.4",
+                    "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.16.4.tgz",
+                    "integrity": "sha512-l+xHtVMteJWeTZZ+f2yLyNjf69X0mhAH8GILXnmoAGAemXbc1DVstvloxOouarvm9xyHHhquzO1Qg5l6xa1VIw==",
                     "requires": {
-                        "@oclif/errors": "^1.3.5",
-                        "@oclif/parser": "^3.8.0",
-                        "debug": "^4.1.1",
-                        "globby": "^11.0.1",
-                        "is-wsl": "^2.1.1",
-                        "tslib": "^2.3.1"
-                    }
-                },
-                "cli-ux": {
-                    "version": "5.6.3",
-                    "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.3.tgz",
-                    "integrity": "sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==",
-                    "requires": {
-                        "@oclif/command": "^1.6.0",
-                        "@oclif/errors": "^1.2.1",
                         "@oclif/linewrap": "^1.0.0",
-                        "@oclif/screen": "^1.0.3",
-                        "ansi-escapes": "^4.3.0",
-                        "ansi-styles": "^4.2.0",
+                        "@oclif/screen": "^3.0.2",
+                        "ansi-escapes": "^4.3.2",
+                        "ansi-styles": "^4.3.0",
                         "cardinal": "^2.1.1",
-                        "chalk": "^4.1.0",
-                        "clean-stack": "^3.0.0",
-                        "cli-progress": "^3.4.0",
-                        "extract-stack": "^2.0.0",
-                        "fs-extra": "^8.1",
+                        "chalk": "^4.1.2",
+                        "clean-stack": "^3.0.1",
+                        "cli-progress": "^3.10.0",
+                        "debug": "^4.3.4",
+                        "ejs": "^3.1.6",
+                        "fs-extra": "^9.1.0",
+                        "get-package-type": "^0.1.0",
+                        "globby": "^11.1.0",
                         "hyperlinker": "^1.0.0",
                         "indent-string": "^4.0.0",
                         "is-wsl": "^2.2.0",
-                        "js-yaml": "^3.13.1",
-                        "lodash": "^4.17.11",
-                        "natural-orderby": "^2.0.1",
-                        "object-treeify": "^1.1.4",
+                        "js-yaml": "^3.14.1",
+                        "natural-orderby": "^2.0.3",
+                        "object-treeify": "^1.1.33",
                         "password-prompt": "^1.1.2",
-                        "semver": "^7.3.2",
-                        "string-width": "^4.2.0",
-                        "strip-ansi": "^6.0.0",
-                        "supports-color": "^8.1.0",
-                        "supports-hyperlinks": "^2.1.0",
-                        "tslib": "^2.0.0"
+                        "semver": "^7.3.7",
+                        "string-width": "^4.2.3",
+                        "strip-ansi": "^6.0.1",
+                        "supports-color": "^8.1.1",
+                        "supports-hyperlinks": "^2.2.0",
+                        "tslib": "^2.3.1",
+                        "widest-line": "^3.1.0",
+                        "wrap-ansi": "^7.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     },
                     "dependencies": {
-                        "ansi-styles": {
-                            "version": "4.3.0",
-                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                        "supports-color": {
+                            "version": "7.2.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
                             "requires": {
-                                "color-convert": "^2.0.1"
-                            }
-                        },
-                        "chalk": {
-                            "version": "4.1.2",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                            "requires": {
-                                "ansi-styles": "^4.1.0",
-                                "supports-color": "^7.1.0"
-                            },
-                            "dependencies": {
-                                "supports-color": {
-                                    "version": "7.2.0",
-                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                                    "requires": {
-                                        "has-flag": "^4.0.0"
-                                    }
-                                }
+                                "has-flag": "^4.0.0"
                             }
                         }
                     }
@@ -17903,28 +16344,10 @@
                     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
                     "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
                 },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
                 "has-flag": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
                 },
                 "supports-color": {
                     "version": "8.1.1",
@@ -17933,616 +16356,148 @@
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
                 }
             }
         },
         "@vonage/cli-plugin-applications": {
             "version": "file:packages/applications",
             "requires": {
-                "@oclif/command": "1.8.16",
-                "@oclif/config": "1.18.3",
-                "@oclif/core": "1.16.3",
-                "@oclif/parser": "3.8.7",
-                "@oclif/test": "^2.1.1",
-                "@vonage/cli-utils": "^1.3.0",
-                "chalk": "5.0.1",
-                "cli-ux": "5.6.3",
+                "@oclif/core": "1.19.0",
+                "@oclif/test": "^2.2.4",
+                "@vonage/cli-utils": "1.3.0",
+                "chalk": "5.1.2",
                 "filenamify": "5.1.1",
                 "lodash": "4.17.21",
                 "prompts": "2.4.2",
                 "unique-names-generator": "4.7.1"
             },
             "dependencies": {
-                "@oclif/config": {
-                    "version": "1.18.3",
-                    "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-                    "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
+                "@oclif/test": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.2.4.tgz",
+                    "integrity": "sha512-bLaapIKHWyeuWCbD64uUCJCH+OJHFlEi6u/3sRPgi00kEyP95mM23IvkggDWEzQNh92IFj1xx5Bg8qnp0E2tjw==",
+                    "dev": true,
                     "requires": {
-                        "@oclif/errors": "^1.3.5",
-                        "@oclif/parser": "^3.8.0",
-                        "debug": "^4.1.1",
-                        "globby": "^11.0.1",
-                        "is-wsl": "^2.1.1",
-                        "tslib": "^2.3.1"
-                    }
-                },
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "requires": {
-                        "color-convert": "^2.0.1"
+                        "@oclif/core": "^1.18.0",
+                        "fancy-test": "^2.0.4"
                     }
                 },
                 "chalk": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-                    "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
-                },
-                "cli-ux": {
-                    "version": "5.6.3",
-                    "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.3.tgz",
-                    "integrity": "sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==",
-                    "requires": {
-                        "@oclif/command": "^1.6.0",
-                        "@oclif/errors": "^1.2.1",
-                        "@oclif/linewrap": "^1.0.0",
-                        "@oclif/screen": "^1.0.3",
-                        "ansi-escapes": "^4.3.0",
-                        "ansi-styles": "^4.2.0",
-                        "cardinal": "^2.1.1",
-                        "chalk": "^4.1.0",
-                        "clean-stack": "^3.0.0",
-                        "cli-progress": "^3.4.0",
-                        "extract-stack": "^2.0.0",
-                        "fs-extra": "^8.1",
-                        "hyperlinker": "^1.0.0",
-                        "indent-string": "^4.0.0",
-                        "is-wsl": "^2.2.0",
-                        "js-yaml": "^3.13.1",
-                        "lodash": "^4.17.11",
-                        "natural-orderby": "^2.0.1",
-                        "object-treeify": "^1.1.4",
-                        "password-prompt": "^1.1.2",
-                        "semver": "^7.3.2",
-                        "string-width": "^4.2.0",
-                        "strip-ansi": "^6.0.0",
-                        "supports-color": "^8.1.0",
-                        "supports-hyperlinks": "^2.1.0",
-                        "tslib": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "chalk": {
-                            "version": "4.1.2",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                            "requires": {
-                                "ansi-styles": "^4.1.0",
-                                "supports-color": "^7.1.0"
-                            },
-                            "dependencies": {
-                                "supports-color": {
-                                    "version": "7.2.0",
-                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                                    "requires": {
-                                        "has-flag": "^4.0.0"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                },
-                "supports-color": {
-                    "version": "8.1.1",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
+                    "integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ=="
                 }
             }
         },
         "@vonage/cli-plugin-conversations": {
             "version": "file:packages/conversations",
             "requires": {
-                "@oclif/command": "1.8.16",
-                "@oclif/config": "1.18.3",
-                "@oclif/core": "1.16.3",
-                "@oclif/parser": "3.8.7",
-                "@oclif/test": "^2.1.1",
-                "@vonage/cli-utils": "^1.3.0",
+                "@oclif/core": "1.19.0",
+                "@oclif/test": "^2.2.4",
+                "@vonage/cli-utils": "1.3.0",
                 "@vonage/jwt": "3.0.0-beta.1",
                 "@vonage/vetch": "3.0.0-beta.3",
-                "chalk": "5.0.1",
-                "cli-ux": "5.6.3",
-                "lodash": "^4.17.21",
+                "chalk": "5.1.2",
+                "lodash": "4.17.21",
                 "nock": "^13.2.9"
             },
             "dependencies": {
-                "@oclif/config": {
-                    "version": "1.18.3",
-                    "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-                    "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
+                "@oclif/test": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.2.4.tgz",
+                    "integrity": "sha512-bLaapIKHWyeuWCbD64uUCJCH+OJHFlEi6u/3sRPgi00kEyP95mM23IvkggDWEzQNh92IFj1xx5Bg8qnp0E2tjw==",
+                    "dev": true,
                     "requires": {
-                        "@oclif/errors": "^1.3.5",
-                        "@oclif/parser": "^3.8.0",
-                        "debug": "^4.1.1",
-                        "globby": "^11.0.1",
-                        "is-wsl": "^2.1.1",
-                        "tslib": "^2.3.1"
-                    }
-                },
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "requires": {
-                        "color-convert": "^2.0.1"
+                        "@oclif/core": "^1.18.0",
+                        "fancy-test": "^2.0.4"
                     }
                 },
                 "chalk": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-                    "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
-                },
-                "cli-ux": {
-                    "version": "5.6.3",
-                    "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.3.tgz",
-                    "integrity": "sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==",
-                    "requires": {
-                        "@oclif/command": "^1.6.0",
-                        "@oclif/errors": "^1.2.1",
-                        "@oclif/linewrap": "^1.0.0",
-                        "@oclif/screen": "^1.0.3",
-                        "ansi-escapes": "^4.3.0",
-                        "ansi-styles": "^4.2.0",
-                        "cardinal": "^2.1.1",
-                        "chalk": "^4.1.0",
-                        "clean-stack": "^3.0.0",
-                        "cli-progress": "^3.4.0",
-                        "extract-stack": "^2.0.0",
-                        "fs-extra": "^8.1",
-                        "hyperlinker": "^1.0.0",
-                        "indent-string": "^4.0.0",
-                        "is-wsl": "^2.2.0",
-                        "js-yaml": "^3.13.1",
-                        "lodash": "^4.17.11",
-                        "natural-orderby": "^2.0.1",
-                        "object-treeify": "^1.1.4",
-                        "password-prompt": "^1.1.2",
-                        "semver": "^7.3.2",
-                        "string-width": "^4.2.0",
-                        "strip-ansi": "^6.0.0",
-                        "supports-color": "^8.1.0",
-                        "supports-hyperlinks": "^2.1.0",
-                        "tslib": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "chalk": {
-                            "version": "4.1.2",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                            "requires": {
-                                "ansi-styles": "^4.1.0",
-                                "supports-color": "^7.1.0"
-                            },
-                            "dependencies": {
-                                "supports-color": {
-                                    "version": "7.2.0",
-                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                                    "requires": {
-                                        "has-flag": "^4.0.0"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                },
-                "supports-color": {
-                    "version": "8.1.1",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
+                    "integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ=="
                 }
             }
         },
         "@vonage/cli-plugin-numberinsight": {
             "version": "file:packages/numberInsight",
             "requires": {
-                "@oclif/core": "^1.16.3",
-                "@oclif/parser": "3.8.7",
+                "@oclif/core": "^1.19.0",
                 "@vonage/cli-utils": "^1.3.0",
-                "chalk": "5.0.1",
-                "cli-ux": "5.6.3",
+                "chalk": "5.1.2",
                 "lodash": "4.17.21",
                 "prompts": "^2.4.2"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
                 "chalk": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-                    "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
-                },
-                "cli-ux": {
-                    "version": "5.6.3",
-                    "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.3.tgz",
-                    "integrity": "sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==",
-                    "requires": {
-                        "@oclif/command": "^1.6.0",
-                        "@oclif/errors": "^1.2.1",
-                        "@oclif/linewrap": "^1.0.0",
-                        "@oclif/screen": "^1.0.3",
-                        "ansi-escapes": "^4.3.0",
-                        "ansi-styles": "^4.2.0",
-                        "cardinal": "^2.1.1",
-                        "chalk": "^4.1.0",
-                        "clean-stack": "^3.0.0",
-                        "cli-progress": "^3.4.0",
-                        "extract-stack": "^2.0.0",
-                        "fs-extra": "^8.1",
-                        "hyperlinker": "^1.0.0",
-                        "indent-string": "^4.0.0",
-                        "is-wsl": "^2.2.0",
-                        "js-yaml": "^3.13.1",
-                        "lodash": "^4.17.11",
-                        "natural-orderby": "^2.0.1",
-                        "object-treeify": "^1.1.4",
-                        "password-prompt": "^1.1.2",
-                        "semver": "^7.3.2",
-                        "string-width": "^4.2.0",
-                        "strip-ansi": "^6.0.0",
-                        "supports-color": "^8.1.0",
-                        "supports-hyperlinks": "^2.1.0",
-                        "tslib": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "chalk": {
-                            "version": "4.1.2",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                            "requires": {
-                                "ansi-styles": "^4.1.0",
-                                "supports-color": "^7.1.0"
-                            },
-                            "dependencies": {
-                                "supports-color": {
-                                    "version": "7.2.0",
-                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                                    "requires": {
-                                        "has-flag": "^4.0.0"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                },
-                "supports-color": {
-                    "version": "8.1.1",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
+                    "integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ=="
                 }
             }
         },
         "@vonage/cli-plugin-numbers": {
             "version": "file:packages/numbers",
             "requires": {
-                "@oclif/command": "1.8.16",
-                "@oclif/config": "1.18.3",
-                "@oclif/core": "1.16.3",
-                "@oclif/parser": "3.8.7",
-                "@oclif/test": "^2.1.1",
-                "@vonage/cli-utils": "^1.3.0",
-                "cli-ux": "5.6.3",
+                "@oclif/core": "1.19.0",
+                "@oclif/test": "^2.2.4",
+                "@vonage/cli-utils": "1.3.0",
                 "nock": "^13.2.9"
             },
             "dependencies": {
-                "@oclif/config": {
-                    "version": "1.18.3",
-                    "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-                    "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
+                "@oclif/test": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.2.4.tgz",
+                    "integrity": "sha512-bLaapIKHWyeuWCbD64uUCJCH+OJHFlEi6u/3sRPgi00kEyP95mM23IvkggDWEzQNh92IFj1xx5Bg8qnp0E2tjw==",
+                    "dev": true,
                     "requires": {
-                        "@oclif/errors": "^1.3.5",
-                        "@oclif/parser": "^3.8.0",
-                        "debug": "^4.1.1",
-                        "globby": "^11.0.1",
-                        "is-wsl": "^2.1.1",
-                        "tslib": "^2.3.1"
+                        "@oclif/core": "^1.18.0",
+                        "fancy-test": "^2.0.4"
                     }
-                },
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "cli-ux": {
-                    "version": "5.6.3",
-                    "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.3.tgz",
-                    "integrity": "sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==",
-                    "requires": {
-                        "@oclif/command": "^1.6.0",
-                        "@oclif/errors": "^1.2.1",
-                        "@oclif/linewrap": "^1.0.0",
-                        "@oclif/screen": "^1.0.3",
-                        "ansi-escapes": "^4.3.0",
-                        "ansi-styles": "^4.2.0",
-                        "cardinal": "^2.1.1",
-                        "chalk": "^4.1.0",
-                        "clean-stack": "^3.0.0",
-                        "cli-progress": "^3.4.0",
-                        "extract-stack": "^2.0.0",
-                        "fs-extra": "^8.1",
-                        "hyperlinker": "^1.0.0",
-                        "indent-string": "^4.0.0",
-                        "is-wsl": "^2.2.0",
-                        "js-yaml": "^3.13.1",
-                        "lodash": "^4.17.11",
-                        "natural-orderby": "^2.0.1",
-                        "object-treeify": "^1.1.4",
-                        "password-prompt": "^1.1.2",
-                        "semver": "^7.3.2",
-                        "string-width": "^4.2.0",
-                        "strip-ansi": "^6.0.0",
-                        "supports-color": "^8.1.0",
-                        "supports-hyperlinks": "^2.1.0",
-                        "tslib": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "chalk": {
-                            "version": "4.1.2",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                            "requires": {
-                                "ansi-styles": "^4.1.0",
-                                "supports-color": "^7.1.0"
-                            },
-                            "dependencies": {
-                                "supports-color": {
-                                    "version": "7.2.0",
-                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                                    "requires": {
-                                        "has-flag": "^4.0.0"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                },
-                "supports-color": {
-                    "version": "8.1.1",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
                 }
             }
         },
         "@vonage/cli-plugin-sms": {
             "version": "file:packages/sms",
             "requires": {
-                "@oclif/parser": "3.8.7",
-                "@oclif/test": "^2.1.1",
+                "@oclif/test": "^2.2.4",
                 "@vonage/cli-utils": "^1.3.0",
                 "@vonage/vetch": "3.0.0-beta.3",
                 "nock": "^13.2.9"
+            },
+            "dependencies": {
+                "@oclif/test": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.2.4.tgz",
+                    "integrity": "sha512-bLaapIKHWyeuWCbD64uUCJCH+OJHFlEi6u/3sRPgi00kEyP95mM23IvkggDWEzQNh92IFj1xx5Bg8qnp0E2tjw==",
+                    "dev": true,
+                    "requires": {
+                        "@oclif/core": "^1.18.0",
+                        "fancy-test": "^2.0.4"
+                    }
+                }
             }
         },
         "@vonage/cli-plugin-users": {
             "version": "file:packages/users",
             "requires": {
-                "@oclif/command": "1.8.16",
-                "@oclif/config": "1.18.3",
-                "@oclif/core": "1.16.3",
-                "@oclif/parser": "3.8.7",
-                "@oclif/test": "^2.1.1",
+                "@oclif/core": "1.19.0",
+                "@oclif/test": "^2.2.4",
                 "@vonage/cli-utils": "^1.3.0",
                 "@vonage/jwt": "3.0.0-beta.0",
                 "@vonage/vetch": "3.0.0-beta.0",
-                "chalk": "5.0.1",
-                "cli-ux": "5.6.3",
+                "chalk": "5.1.2",
                 "lodash": "4.17.21"
             },
             "dependencies": {
-                "@oclif/config": {
-                    "version": "1.18.3",
-                    "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-                    "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
+                "@oclif/test": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.2.4.tgz",
+                    "integrity": "sha512-bLaapIKHWyeuWCbD64uUCJCH+OJHFlEi6u/3sRPgi00kEyP95mM23IvkggDWEzQNh92IFj1xx5Bg8qnp0E2tjw==",
+                    "dev": true,
                     "requires": {
-                        "@oclif/errors": "^1.3.5",
-                        "@oclif/parser": "^3.8.0",
-                        "debug": "^4.1.1",
-                        "globby": "^11.0.1",
-                        "is-wsl": "^2.1.1",
-                        "tslib": "^2.3.1"
+                        "@oclif/core": "^1.18.0",
+                        "fancy-test": "^2.0.4"
                     }
                 },
                 "@vonage/jwt": {
@@ -18563,146 +16518,25 @@
                         "node-fetch": "^2.6.1"
                     }
                 },
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
                 "chalk": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-                    "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
-                },
-                "cli-ux": {
-                    "version": "5.6.3",
-                    "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.3.tgz",
-                    "integrity": "sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==",
-                    "requires": {
-                        "@oclif/command": "^1.6.0",
-                        "@oclif/errors": "^1.2.1",
-                        "@oclif/linewrap": "^1.0.0",
-                        "@oclif/screen": "^1.0.3",
-                        "ansi-escapes": "^4.3.0",
-                        "ansi-styles": "^4.2.0",
-                        "cardinal": "^2.1.1",
-                        "chalk": "^4.1.0",
-                        "clean-stack": "^3.0.0",
-                        "cli-progress": "^3.4.0",
-                        "extract-stack": "^2.0.0",
-                        "fs-extra": "^8.1",
-                        "hyperlinker": "^1.0.0",
-                        "indent-string": "^4.0.0",
-                        "is-wsl": "^2.2.0",
-                        "js-yaml": "^3.13.1",
-                        "lodash": "^4.17.11",
-                        "natural-orderby": "^2.0.1",
-                        "object-treeify": "^1.1.4",
-                        "password-prompt": "^1.1.2",
-                        "semver": "^7.3.2",
-                        "string-width": "^4.2.0",
-                        "strip-ansi": "^6.0.0",
-                        "supports-color": "^8.1.0",
-                        "supports-hyperlinks": "^2.1.0",
-                        "tslib": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "chalk": {
-                            "version": "4.1.2",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                            "requires": {
-                                "ansi-styles": "^4.1.0",
-                                "supports-color": "^7.1.0"
-                            },
-                            "dependencies": {
-                                "supports-color": {
-                                    "version": "7.2.0",
-                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                                    "requires": {
-                                        "has-flag": "^4.0.0"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                },
-                "supports-color": {
-                    "version": "8.1.1",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
+                    "integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ=="
                 }
             }
         },
         "@vonage/cli-utils": {
             "version": "file:packages/utils",
             "requires": {
-                "@oclif/command": "1.8.16",
-                "@oclif/config": "1.18.3",
-                "@oclif/core": "1.16.3",
-                "@types/node": "18.7.18",
+                "@oclif/core": "^1.19.0",
+                "@types/node": "18.11.0",
                 "@vonage/server-sdk": "2.11.2"
             },
             "dependencies": {
-                "@oclif/config": {
-                    "version": "1.18.3",
-                    "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-                    "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
-                    "requires": {
-                        "@oclif/errors": "^1.3.5",
-                        "@oclif/parser": "^3.8.0",
-                        "debug": "^4.1.1",
-                        "globby": "^11.0.1",
-                        "is-wsl": "^2.1.1",
-                        "tslib": "^2.3.1"
-                    }
+                "@types/node": {
+                    "version": "18.11.0",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
+                    "integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w=="
                 }
             }
         },
@@ -18744,8 +16578,7 @@
         "acorn": {
             "version": "8.8.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-            "dev": true
+            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
         },
         "acorn-jsx": {
             "version": "5.3.2",
@@ -18753,6 +16586,11 @@
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "requires": {}
+        },
+        "acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
         },
         "add-stream": {
             "version": "1.0.0",
@@ -18867,6 +16705,11 @@
                 "delegates": "^1.0.0",
                 "readable-stream": "^3.6.0"
             }
+        },
+        "arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
         },
         "argparse": {
             "version": "1.0.10",
@@ -19274,12 +17117,6 @@
                 "readdirp": "~3.6.0"
             }
         },
-        "chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true
-        },
         "ci-info": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
@@ -19332,128 +17169,6 @@
             "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
             "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
             "dev": true
-        },
-        "cli-ux": {
-            "version": "5.6.7",
-            "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.7.tgz",
-            "integrity": "sha512-dsKAurMNyFDnO6X1TiiRNiVbL90XReLKcvIq4H777NMqXGBxBws23ag8ubCJE97vVZEgWG2eSUhsyLf63Jv8+g==",
-            "dev": true,
-            "requires": {
-                "@oclif/command": "^1.8.15",
-                "@oclif/errors": "^1.3.5",
-                "@oclif/linewrap": "^1.0.0",
-                "@oclif/screen": "^1.0.4",
-                "ansi-escapes": "^4.3.0",
-                "ansi-styles": "^4.2.0",
-                "cardinal": "^2.1.1",
-                "chalk": "^4.1.0",
-                "clean-stack": "^3.0.0",
-                "cli-progress": "^3.4.0",
-                "extract-stack": "^2.0.0",
-                "fs-extra": "^8.1",
-                "hyperlinker": "^1.0.0",
-                "indent-string": "^4.0.0",
-                "is-wsl": "^2.2.0",
-                "js-yaml": "^3.13.1",
-                "lodash": "^4.17.21",
-                "natural-orderby": "^2.0.1",
-                "object-treeify": "^1.1.4",
-                "password-prompt": "^1.1.2",
-                "semver": "^7.3.2",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "supports-color": "^8.1.0",
-                "supports-hyperlinks": "^2.1.0",
-                "tslib": "^2.0.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-                    "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "7.2.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                            "dev": true,
-                            "requires": {
-                                "has-flag": "^4.0.0"
-                            }
-                        }
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                },
-                "supports-color": {
-                    "version": "8.1.1",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-                    "dev": true
-                }
-            }
         },
         "cli-width": {
             "version": "3.0.0",
@@ -19612,8 +17327,7 @@
         "content-type": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-            "dev": true
+            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
         },
         "conventional-changelog-angular": {
             "version": "5.0.13",
@@ -19820,6 +17534,11 @@
                 }
             }
         },
+        "create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+        },
         "cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -19969,6 +17688,11 @@
                 "wrappy": "1"
             }
         },
+        "diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+        },
         "diff-sequences": {
             "version": "29.0.0",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.0.0.tgz",
@@ -20044,12 +17768,6 @@
             "integrity": "sha512-UyvEPae0wvzsyNJhVfGeFSOlUkHEze8xSIiExO5tZQ8QTr7obFiJWGk3U4e7afFOJMQJDszqU/3Pk5jtKiaSEg==",
             "dev": true
         },
-        "emoji-regex": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
-            "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
-            "dev": true
-        },
         "encoding": {
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
@@ -20110,7 +17828,6 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
@@ -20635,13 +18352,6 @@
                 }
             }
         },
-        "eslint-config-prettier": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-            "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-            "dev": true,
-            "requires": {}
-        },
         "eslint-config-xo": {
             "version": "0.35.0",
             "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.35.0.tgz",
@@ -20754,15 +18464,6 @@
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 }
-            }
-        },
-        "eslint-plugin-prettier": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-            "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
-            "dev": true,
-            "requires": {
-                "prettier-linter-helpers": "^1.0.0"
             }
         },
         "eslint-plugin-unicorn": {
@@ -20972,20 +18673,15 @@
                 }
             }
         },
-        "extract-stack": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/extract-stack/-/extract-stack-2.0.0.tgz",
-            "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ=="
-        },
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
         },
         "fancy-test": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fancy-test/-/fancy-test-2.0.0.tgz",
-            "integrity": "sha512-SFb2D/VX9SV+wNYXO1IIh1wyxUC1GS0mYCFJOWD1ia7MPj9yE2G8jaPkw4t/pg0Sj7/YJP56OzMY4nAuJSOugQ==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/fancy-test/-/fancy-test-2.0.5.tgz",
+            "integrity": "sha512-ASPLNVkHSSIdRI/uLlK+XGhf1ul/MpRN9VE84ehXL+FOprQjXrDXX3wW1wqKvtcTTC+AW0E0RxdpJ5IEopjhQA==",
             "dev": true,
             "requires": {
                 "@types/chai": "*",
@@ -21002,12 +18698,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        },
-        "fast-diff": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-            "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
-            "dev": true
         },
         "fast-glob": {
             "version": "3.2.11",
@@ -21120,15 +18810,6 @@
             "requires": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
-            }
-        },
-        "find-yarn-workspace-root": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-            "dev": true,
-            "requires": {
-                "micromatch": "^4.0.2"
             }
         },
         "flat": {
@@ -21342,15 +19023,6 @@
             "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
             "dev": true
         },
-        "get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-            "dev": true,
-            "requires": {
-                "pump": "^3.0.0"
-            }
-        },
         "getpass": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -21434,15 +19106,6 @@
             "dev": true,
             "requires": {
                 "ini": "^1.3.2"
-            }
-        },
-        "github-slugger": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
-            "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
-            "dev": true,
-            "requires": {
-                "emoji-regex": ">=6.0.0 <=6.1.1"
             }
         },
         "glob": {
@@ -21579,7 +19242,6 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/http-call/-/http-call-5.3.0.tgz",
             "integrity": "sha512-ahwimsC23ICE4kPl9xTBjKB4inbRaeLyZeRunC/1Jy/Z6X8tv22MEAjK+KBOMSVLaqXPTTmd8638waVIKLGx2w==",
-            "dev": true,
             "requires": {
                 "content-type": "^1.0.4",
                 "debug": "^4.1.1",
@@ -21878,8 +19540,7 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
         "is-binary-path": {
             "version": "2.1.0",
@@ -21985,8 +19646,7 @@
         "is-retry-allowed": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-            "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-            "dev": true
+            "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
         },
         "is-ssh": {
             "version": "1.4.0",
@@ -22000,8 +19660,7 @@
         "is-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-            "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-            "dev": true
+            "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
         },
         "is-text-path": {
             "version": "1.0.1",
@@ -22423,8 +20082,7 @@
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-            "dev": true
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
         },
         "json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -22906,6 +20564,11 @@
                 }
             }
         },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+        },
         "make-fetch-happen": {
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
@@ -23130,12 +20793,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-            "dev": true
-        },
-        "mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "dev": true
         },
         "mkdirp-infer-owner": {
@@ -23561,7 +21218,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
             "requires": {
                 "path-key": "^3.0.0"
             }
@@ -24075,7 +21731,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-            "dev": true,
             "requires": {
                 "error-ex": "^1.3.1",
                 "json-parse-better-errors": "^1.0.1"
@@ -24175,8 +21830,7 @@
         "path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         },
         "path-parse": {
             "version": "1.0.7",
@@ -24207,8 +21861,7 @@
         "pify": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-            "dev": true
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         },
         "pkg-dir": {
             "version": "4.2.0",
@@ -24230,21 +21883,6 @@
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true
-        },
-        "prettier": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-            "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-            "dev": true
-        },
-        "prettier-linter-helpers": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-            "dev": true,
-            "requires": {
-                "fast-diff": "^1.1.2"
-            }
         },
         "pretty-format": {
             "version": "29.0.3",
@@ -24353,16 +21991,6 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
             "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
         },
-        "pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dev": true,
-            "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -24373,158 +22001,6 @@
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
             "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
             "dev": true
-        },
-        "qqjs": {
-            "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/qqjs/-/qqjs-0.3.11.tgz",
-            "integrity": "sha512-pB2X5AduTl78J+xRSxQiEmga1jQV0j43jOPs/MTgTLApGFEOn6NgdE2dEjp7nvDtjkIOZbvFIojAiYUx6ep3zg==",
-            "dev": true,
-            "requires": {
-                "chalk": "^2.4.1",
-                "debug": "^4.1.1",
-                "execa": "^0.10.0",
-                "fs-extra": "^6.0.1",
-                "get-stream": "^5.1.0",
-                "glob": "^7.1.2",
-                "globby": "^10.0.1",
-                "http-call": "^5.1.2",
-                "load-json-file": "^6.2.0",
-                "pkg-dir": "^4.2.0",
-                "tar-fs": "^2.0.0",
-                "tmp": "^0.1.0",
-                "write-json-file": "^4.1.1"
-            },
-            "dependencies": {
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "dev": true,
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
-                "execa": {
-                    "version": "0.10.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-                    "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-                    "dev": true,
-                    "requires": {
-                        "cross-spawn": "^6.0.0",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "get-stream": {
-                            "version": "3.0.0",
-                            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-                            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-                            "dev": true
-                        }
-                    }
-                },
-                "fs-extra": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-                    "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
-                "globby": {
-                    "version": "10.0.2",
-                    "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
-                    "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
-                    "dev": true,
-                    "requires": {
-                        "@types/glob": "^7.1.1",
-                        "array-union": "^2.1.0",
-                        "dir-glob": "^3.0.1",
-                        "fast-glob": "^3.0.3",
-                        "glob": "^7.1.3",
-                        "ignore": "^5.1.1",
-                        "merge2": "^1.2.3",
-                        "slash": "^3.0.0"
-                    }
-                },
-                "is-stream": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-                    "dev": true
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                },
-                "npm-run-path": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-                    "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-                    "dev": true,
-                    "requires": {
-                        "path-key": "^2.0.0"
-                    }
-                },
-                "path-key": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true
-                },
-                "shebang-command": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-                    "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-                    "dev": true,
-                    "requires": {
-                        "shebang-regex": "^1.0.0"
-                    }
-                },
-                "shebang-regex": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-                    "dev": true
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-                    "dev": true
-                },
-                "which": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-                    "dev": true,
-                    "requires": {
-                        "isexe": "^2.0.0"
-                    }
-                }
-            }
         },
         "qs": {
             "version": "6.5.3",
@@ -25035,9 +22511,9 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
             "requires": {
                 "lru-cache": "^6.0.0"
             }
@@ -25346,12 +22822,6 @@
             "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
             "dev": true
         },
-        "strip-eof": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-            "dev": true
-        },
         "strip-final-newline": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -25480,18 +22950,6 @@
                 }
             }
         },
-        "tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "dev": true,
-            "requires": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
         "tar-stream": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -25536,26 +22994,6 @@
             "dev": true,
             "requires": {
                 "readable-stream": "3"
-            }
-        },
-        "tmp": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-            "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-            "dev": true,
-            "requires": {
-                "rimraf": "^2.6.3"
-            },
-            "dependencies": {
-                "rimraf": {
-                    "version": "2.7.1",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                }
             }
         },
         "to-fast-properties": {
@@ -25606,6 +23044,26 @@
                     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
                     "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
                 }
+            }
+        },
+        "ts-node": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+            "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+            "requires": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
             }
         },
         "tsconfig-paths": {
@@ -25710,8 +23168,7 @@
         "typescript": {
             "version": "4.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-            "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
-            "dev": true
+            "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=="
         },
         "uglify-js": {
             "version": "3.17.0",
@@ -25784,6 +23241,11 @@
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
+        },
+        "v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
@@ -26034,6 +23496,16 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
             "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
             "dev": true
+        },
+        "yarn": {
+            "version": "1.22.19",
+            "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.19.tgz",
+            "integrity": "sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ=="
+        },
+        "yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
         },
         "yocto-queue": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
         "packages/*"
     ],
     "devDependencies": {
-        "@oclif/core": "1.16.3",
-        "@oclif/dev-cli": "1.26.10",
-        "@oclif/test": "2.1.1",
         "@types/jest": "29.0.3",
         "@typescript-eslint/eslint-plugin": "5.38.0",
         "@typescript-eslint/parser": "5.38.0",

--- a/packages/applications/.npmrc
+++ b/packages/applications/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+bin-links=true
+engine-strict=true

--- a/packages/applications/bin/run
+++ b/packages/applications/bin/run
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-
-require('@oclif/command').run()
-.catch(require('@oclif/errors/handle'))

--- a/packages/applications/bin/run.cmd
+++ b/packages/applications/bin/run.cmd
@@ -1,3 +1,0 @@
-@echo off
-
-node "%~dp0\run" %*

--- a/packages/applications/package.json
+++ b/packages/applications/package.json
@@ -4,22 +4,16 @@
     "version": "1.2.0",
     "author": "Vonage Dev Rel <devrel@vonage.com>",
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
-    "module": true,
+    "types": "dist/index.d.ts",
+    "type": "module",
     "dependencies": {
-        "@oclif/command": "1.8.16",
-        "@oclif/config": "1.18.3",
-        "@oclif/core": "1.16.3",
-        "@oclif/parser": "3.8.7",
-        "@vonage/cli-utils": "^1.3.0",
-        "chalk": "5.0.1",
-        "cli-ux": "5.6.3",
+        "@oclif/core": "1.19.0",
+        "@vonage/cli-utils": "1.3.0",
+        "chalk": "5.1.2",
         "filenamify": "5.1.1",
         "lodash": "4.17.21",
         "prompts": "2.4.2",
         "unique-names-generator": "4.7.1"
-    },
-    "engines": {
-        "node": ">=12.0.0"
     },
     "files": [
         "/dist",
@@ -28,26 +22,22 @@
         "/node_modules",
         "/oclif.manifest.json"
     ],
+    "engines": {
+        "node": ">=14.0.0"
+    },
     "homepage": "https://github.com/Vonage/vonage-cli",
     "keywords": [
         "oclif-plugin"
     ],
     "license": "Apache 2.0",
     "oclif": {
-        "commands": "./dist/commands",
-        "bin": "oclif-example",
-        "devPlugins": [
-            "@oclif/plugin-help"
-        ]
+        "commands": "./dist/commands"
     },
     "repository": "Vonage/vonage-cli",
     "scripts": {
-        "postpack": "rm -f oclif.manifest.json",
-        "prepack": "rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
+        "postpack": "npx shx rm -f oclif.manifest.json",
+        "prepack": "npx shx rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
         "version": "oclif-dev readme && git add README.md",
-        "build": "tsc -b"
-    },
-    "devDependencies": {
-        "@oclif/test": "^2.1.1"
+        "build": "npx shx rm -rf dist tsconfig.tsbuildinfo && tsc --build --verbose"
     }
 }

--- a/packages/applications/src/app_base.ts
+++ b/packages/applications/src/app_base.ts
@@ -1,26 +1,7 @@
-import BaseCommand from '@vonage/cli-utils';
-import { OutputFlags } from '@oclif/parser';
-import { ArgInput } from '@oclif/core/lib/interfaces';
+import VonageCommand from '@vonage/cli-utils';
 
-export default abstract class AppCommand<
-    T extends typeof BaseCommand.flags,
-> extends BaseCommand<T> {
-    protected parsedArgs;
-    protected parsedFlags;
-
-    static flags: OutputFlags<typeof BaseCommand.flags> = {
-        ...BaseCommand.flags,
-        /* ... */
-    };
-
-    static args: ArgInput = {
-        ...BaseCommand.args,
-    };
-
-    async catch(error: any) {
-        return super.catch(error);
-    }
-
+export default abstract class AppCommand<T>
+    extends VonageCommand<typeof AppCommand> {
     get allApplications(): any {
         return new Promise((res, rej) => {
             this.vonage.applications.get(

--- a/packages/applications/src/commands/apps/create.ts
+++ b/packages/applications/src/commands/apps/create.ts
@@ -1,19 +1,19 @@
-import AppCommand from '../../app_base';
-import { OutputFlags } from '@oclif/parser';
+import AppCommand from '../../app_base.js';
 import { ArgInput } from '@oclif/core/lib/interfaces';
-import { flags } from '@oclif/command';
-import { prompt } from 'prompts';
-import { webhookQuestions, sanitizeFileName } from '../../helpers';
+import { Flags, CliUx } from '@oclif/core';
+import prompts from 'prompts';
+import { webhookQuestions, sanitizeFileName } from '../../helpers/index.js';
 import {
     uniqueNamesGenerator,
     adjectives,
     animals,
 } from 'unique-names-generator';
-import { merge } from 'lodash';
 import { writeFileSync } from 'fs';
-import cli from 'cli-ux';
-import chalk from 'chalk';
 import _ from 'lodash';
+import chalk from 'chalk';
+const { prompt } = prompts;
+
+const cli = CliUx.ux;
 
 const shortName = uniqueNamesGenerator({
     // colors can be omitted here as not used
@@ -21,26 +21,10 @@ const shortName = uniqueNamesGenerator({
     length: 2,
 });
 
-interface CreateFlags {
-    voice_answer_url: any;
-    voice_answer_http: any;
-    voice_event_url: any;
-    voice_event_http: any;
-    messages_inbound_url: any;
-    messages_inbound_http: any;
-    messages_status_url: any;
-    messages_status_http: any;
-    rtc_event_url: any;
-    rtc_event_http: any;
-    vbc: any;
-    improve_ai: any;
-}
-
 const kbArticle = 'https://help.nexmo.com/hc/en-us/articles/4401914566036';
 
-export default class ApplicationsCreate extends AppCommand<
-    typeof ApplicationsCreate.flags
-> {
+export default class ApplicationsCreate
+    extends AppCommand<typeof ApplicationsCreate> {
     static description = 'create a new Vonage application';
 
     static examples = [
@@ -48,75 +32,74 @@ export default class ApplicationsCreate extends AppCommand<
         'vonage apps:create APP_NAME --voice_answer_url=https://www.sample.com --voice_event_url=https://www.sample.com',
     ];
 
-    static flags: OutputFlags<typeof AppCommand.flags> & CreateFlags = {
-        ...AppCommand.flags,
-        voice_answer_url: flags.string({
+    static flags = {
+        voice_answer_url: Flags.string({
             description: 'Voice Answer Webhook URL Address',
             dependsOn: ['voice_event_url'],
-            parse: (input) =>
+            parse: async (input) =>
                 `{"voice": {"webhooks": {"answer_url": {"address": "${input}"}}}}`,
         }),
-        voice_answer_http: flags.string({
+        voice_answer_http: Flags.string({
             description: 'Voice Answer Webhook HTTP Method',
             options: ['GET', 'POST'],
             dependsOn: ['voice_answer_url'],
-            parse: (input) =>
+            parse: async (input) =>
                 `{"voice": {"webhooks": {"answer_url": {"http_method": "${input}"}}}}`,
         }),
-        voice_event_url: flags.string({
+        voice_event_url: Flags.string({
             description: 'Voice Event Webhook URL Address',
             dependsOn: ['voice_answer_url'],
-            parse: (input) =>
+            parse: async (input) =>
                 `{"voice": {"webhooks": {"event_url": {"address": "${input}"}}}}`,
         }),
-        voice_event_http: flags.string({
+        voice_event_http: Flags.string({
             description: 'Voice Event Webhook HTTP Method',
             options: ['GET', 'POST'],
             dependsOn: ['voice_event_url'],
-            parse: (input) =>
+            parse: async (input) =>
                 `{"voice": {"webhooks": {"event_url": {"http_method": "${input}"}}}}`,
         }),
-        messages_inbound_url: flags.string({
+        messages_inbound_url: Flags.string({
             description: 'Messages Inbound Webhook URL Address',
-            parse: (input) =>
+            parse: async (input) =>
                 `{"messages": {"webhooks": {"inbound_url": {"address": "${input}"}}}}`,
         }),
-        messages_inbound_http: flags.string({
+        messages_inbound_http: Flags.string({
             description: 'Messages Inbound Webhook HTTP Method',
             options: ['GET', 'POST'],
             dependsOn: ['messages_inbound_url'],
-            parse: (input) =>
+            parse: async (input) =>
                 `{"messages": {"webhooks": {"inbound_url": {"http_method": "${input}"}}}}`,
         }),
-        messages_status_url: flags.string({
+        messages_status_url: Flags.string({
             description: 'Messages Status Webhook URL Address',
-            parse: (input) =>
+            parse: async (input) =>
                 `{"messages": {"webhooks": {"status_url": {"address": "${input}"}}}}`,
         }),
-        messages_status_http: flags.string({
+        messages_status_http: Flags.string({
             description: 'Messages Status Webhook HTTP Method',
             options: ['GET', 'POST'],
             dependsOn: ['messages_status_url'],
-            parse: (input) =>
+            parse: async (input) =>
                 `{"messages": {"webhooks": {"status_url": {"http_method": "${input}"}}}}`,
         }),
-        rtc_event_url: flags.string({
+        rtc_event_url: Flags.string({
             description: 'RTC Event Webhook URL Address',
-            parse: (input) =>
+            parse: async (input) =>
                 `{"rtc": {"webhooks": {"event_url": {"address": "${input}"}}}}`,
         }),
-        rtc_event_http: flags.string({
+        rtc_event_http: Flags.string({
             description: 'RTC Event Webhook HTTP Method',
             options: ['GET', 'POST'],
             dependsOn: ['rtc_event_url'],
-            parse: (input) =>
+            parse: async (input) =>
                 `{"rtc": {"webhooks": {"event_url": {"http_method": "${input}"}}}}`,
         }),
-        vbc: flags.boolean({
+        vbc: Flags.boolean({
             description: 'VBC Capabilities Enabled',
-            parse: () => `{"vbc": {}}`,
+            parse: async () => `{"vbc": {}}`,
         }),
-        improve_ai: flags.boolean({
+        improve_ai: Flags.boolean({
             description: `Allow use of data for AI training? Read data collection disclosure - ${kbArticle}`,
         }),
     };
@@ -149,7 +132,7 @@ export default class ApplicationsCreate extends AppCommand<
                 [],
             );
 
-            merge(response.capabilities, ...tobeAssigned);
+            _.merge(response.capabilities, ...tobeAssigned);
 
             response.name = args.name;
         }

--- a/packages/applications/src/commands/apps/delete.ts
+++ b/packages/applications/src/commands/apps/delete.ts
@@ -1,8 +1,11 @@
-import AppCommand from '../../app_base';
-import { prompt } from 'prompts';
+import AppCommand from '../../app_base.js';
 import { ArgInput } from '@oclif/core/lib/interfaces';
 import chalk from 'chalk';
-import cli from 'cli-ux';
+import { CliUx } from '@oclif/core';
+import prompts from 'prompts';
+
+const { prompt } = prompts;
+const cli = CliUx.ux;
 
 export default class ApplicationsDelete extends AppCommand<
     typeof ApplicationsDelete.flags

--- a/packages/applications/src/commands/apps/index.ts
+++ b/packages/applications/src/commands/apps/index.ts
@@ -1,16 +1,15 @@
-import AppCommand from '../../app_base';
-import cli from 'cli-ux';
-import { OutputFlags } from '@oclif/parser';
+import AppCommand from '../../app_base.js';
+import { CliUx } from '@oclif/core';
 
-export default class ApplicationsLink extends AppCommand<
-    typeof ApplicationsLink.flags
-> {
+const cli = CliUx.ux;
+
+export default class ApplicationsLink
+    extends AppCommand<typeof ApplicationsLink> {
     static description = 'manage your Vonage applications';
 
     static examples = ['vonage apps', 'vonage apps --output=json'];
 
-    static flags: OutputFlags<typeof AppCommand.flags> = {
-        ...AppCommand.flags,
+    static flags = {
         ...cli.table.flags({
             except: ['columns', 'no-truncate', 'csv', 'extended', 'no-header'],
         }),

--- a/packages/applications/src/commands/apps/link.ts
+++ b/packages/applications/src/commands/apps/link.ts
@@ -1,17 +1,19 @@
-import { flags } from '@oclif/parser';
-import AppCommand from '../../app_base';
+import { Flags } from '@oclif/core';
+import AppCommand from '../../app_base.js';
 import { ArgInput } from '@oclif/core/lib/interfaces';
+import { VonageCliFlags } from '@vonage/cli-utils';
 
-export default class ApplicationsLink extends AppCommand<
-    typeof ApplicationsLink.flags
-> {
+interface AppLinkParams extends VonageCliFlags<typeof ApplicationsLink> {
+    number: string
+}
+
+export default class ApplicationsLink extends AppCommand<ApplicationsLink> {
     static description = 'link numbers to Vonage application';
 
     static usage = `apps:link [APPID] --number=[NUMBER]`;
 
     static flags = {
-        ...AppCommand.flags,
-        number: flags.string({
+        number: Flags.string({
             description: 'Owned number to be assigned',
             required: true,
         }),
@@ -20,26 +22,22 @@ export default class ApplicationsLink extends AppCommand<
     static args: ArgInput = [{ name: 'appId', required: true }];
 
     async run() {
-        const flags = this.parsedFlags;
-        const args = this.parsedArgs!;
+        const { number } = this.flags as AppLinkParams;
+        const args = this.parsedArgs ?? {};
 
-        const number = await this.listNumbers(flags.number);
+        const oldNumber = await this.listNumbers(number as string);
 
         // update the number with appid, lvn, country
         const response = await this.updateNumber(
-            flags.number,
-            number.numbers[0].country,
+            number as string,
+            oldNumber?.numbers[0]?.country,
             args.appId,
         );
 
         if (response['error-code'] === '200') {
             this.log(
-                `Number '${flags.number}' is assigned to application '${args.appId}'.`,
+                `Number '${number}' is assigned to application '${args.appId}'.`,
             );
         }
-    }
-
-    async catch(error: any) {
-        return super.catch(error);
     }
 }

--- a/packages/applications/src/commands/apps/show.ts
+++ b/packages/applications/src/commands/apps/show.ts
@@ -1,17 +1,13 @@
-import AppCommand from '../../app_base';
-import { prompt } from 'prompts';
+import AppCommand from '../../app_base.js';
 import { ArgInput } from '@oclif/core/lib/interfaces';
 import chalk from 'chalk';
 import _ from 'lodash';
+import { CliUx } from '@oclif/core';
 
-export default class ApplicationsShow extends AppCommand<
-    typeof ApplicationsShow.flags
-> {
+
+export default class ApplicationsShow
+    extends AppCommand<typeof ApplicationsShow> {
     static description = 'show Vonage application details';
-
-    static flags = {
-        ...AppCommand.flags,
-    };
 
     static examples = [];
 
@@ -31,18 +27,12 @@ export default class ApplicationsShow extends AppCommand<
         let response = args;
 
         if (!args.appId) {
-            const appData = await this.allApplications;
-            const appList = appData['_embedded'].applications;
-
-            response = await prompt([
+            response = await CliUx.ux.prompt(
+                'Your Applications',
                 {
-                    type: 'autocomplete',
-                    name: 'appId',
-                    message: 'Your Applications',
-                    choices: this.setQuestions(appList),
-                    initial: 0,
+                    required: true,
                 },
-            ]);
+            );
         }
 
         const output = await this.getSingleApplication(response.appId);

--- a/packages/applications/src/commands/apps/unlink.ts
+++ b/packages/applications/src/commands/apps/unlink.ts
@@ -1,27 +1,25 @@
-import AppCommand from '../../app_base';
-import { OutputFlags, flags } from '@oclif/parser';
+import AppCommand from '../../app_base.js';
+import { Flags } from '@oclif/core';
+import { VonageCliFlags } from '@vonage/cli-utils';
 
-interface UnLinkFlags {
-    number: any;
+interface AppUnlinkParams extends VonageCliFlags<typeof ApplicationsUnlink> {
+    number: string
 }
 
-export default class ApplicationsUnlink extends AppCommand<
-    typeof ApplicationsUnlink.flags
-> {
+export default class ApplicationsUnlink
+    extends AppCommand<typeof ApplicationsUnlink> {
     static description = 'unlink numbers from Vonage application';
 
     static examples = [];
 
     static flags = {
-        ...AppCommand.flags,
-        number: flags.string({
+        number: Flags.string({
             description: 'Owned number to be unassigned',
         }),
     };
 
     async run() {
-        const flags = this.parsedFlags as OutputFlags<typeof AppCommand.flags> &
-            UnLinkFlags;
+        const flags = this.parsedFlags as AppUnlinkParams;
 
         if (!flags.number) {
             this.error(new Error('Flag "number" not provided.'));

--- a/packages/applications/src/commands/apps/update.ts
+++ b/packages/applications/src/commands/apps/update.ts
@@ -1,15 +1,17 @@
-import AppCommand from '../../app_base';
-import { OutputFlags } from '@oclif/parser';
+import AppCommand from '../../app_base.js';
 import { ArgInput } from '@oclif/core/lib/interfaces';
-import { flags } from '@oclif/command';
-import { prompt } from 'prompts';
-import { webhookQuestions } from '../../helpers';
-import { merge } from 'lodash';
-import cli from 'cli-ux';
+import { CliUx, Flags } from '@oclif/core';
+import { webhookQuestions } from '../../helpers/index.js';
 import chalk from 'chalk';
 import _ from 'lodash';
+import { VonageCliFlags } from '@vonage/cli-utils';
+import prompts from 'prompts';
 
-interface UpdateFlags {
+const { prompt } = prompts;
+
+const cli = CliUx.ux;
+
+interface UpdateFlags extends VonageCliFlags<typeof ApplicationsUpdate>{
     voice_answer_url: any;
     voice_answer_http: any;
     voice_event_url: any;
@@ -33,64 +35,63 @@ export default class ApplicationsUpdate extends AppCommand<
         'vonage apps:update APP_ID --voice_answer_url="https://www.example.com/answer',
     ];
 
-    static flags: OutputFlags<typeof AppCommand.flags> & UpdateFlags = {
-        ...AppCommand.flags,
-        voice_answer_url: flags.string({
+    static flags = {
+        voice_answer_url: Flags.string({
             description: 'Voice Answer Webhook URL Address',
-            parse: (input) =>
+            parse: async (input) =>
                 `{"voice": {"webhooks": {"answer_url": {"address": "${input}"}}}}`,
         }),
-        voice_answer_http: flags.string({
+        voice_answer_http: Flags.string({
             description: 'Voice Answer Webhook HTTP Method',
             options: ['GET', 'POST'],
-            parse: (input) =>
+            parse: async (input) =>
                 `{"voice": {"webhooks": {"answer_url": {"http_method": "${input}"}}}}`,
         }),
-        voice_event_url: flags.string({
+        voice_event_url: Flags.string({
             description: 'Voice Event Webhook URL Address',
-            parse: (input) =>
+            parse: async (input) =>
                 `{"voice": {"webhooks": {"event_url": {"address": "${input}"}}}}`,
         }),
-        voice_event_http: flags.string({
+        voice_event_http: Flags.string({
             description: 'Voice Event Webhook HTTP Method',
             options: ['GET', 'POST'],
-            parse: (input) =>
+            parse: async (input) =>
                 `{"voice": {"webhooks": {"event_url": {"http_method": "${input}"}}}}`,
         }),
-        messages_inbound_url: flags.string({
+        messages_inbound_url: Flags.string({
             description: 'Messages Inbound Webhook URL Address',
-            parse: (input) =>
+            parse: async (input) =>
                 `{"messages": {"webhooks": {"inbound_url": {"address": "${input}"}}}}`,
         }),
-        messages_inbound_http: flags.string({
+        messages_inbound_http: Flags.string({
             description: 'Messages Inbound Webhook HTTP Method',
             options: ['GET', 'POST'],
-            parse: (input) =>
+            parse: async (input) =>
                 `{"messages": {"webhooks": {"inbound_url": {"http_method": "${input}"}}}}`,
         }),
-        messages_status_url: flags.string({
+        messages_status_url: Flags.string({
             description: 'Messages Status Webhook URL Address',
-            parse: (input) =>
+            parse: async (input) =>
                 `{"messages": {"webhooks": {"status_url": {"address": "${input}"}}}}`,
         }),
-        messages_status_http: flags.string({
+        messages_status_http: Flags.string({
             description: 'Messages Status Webhook HTTP Method',
             options: ['GET', 'POST'],
-            parse: (input) =>
+            parse: async (input) =>
                 `{"messages": {"webhooks": {"status_url": {"http_method": "${input}"}}}}`,
         }),
-        rtc_event_url: flags.string({
+        rtc_event_url: Flags.string({
             description: 'RTC Event Webhook URL Address',
-            parse: (input) =>
+            parse: async (input) =>
                 `{"rtc": {"webhooks": {"event_url": {"address": "${input}"}}}}`,
         }),
-        rtc_event_http: flags.string({
+        rtc_event_http: Flags.string({
             description: 'RTC Event Webhook HTTP Method',
             options: ['GET', 'POST'],
-            parse: (input) =>
+            parse: async (input) =>
                 `{"rtc": {"webhooks": {"event_url": {"http_method": "${input}"}}}}`,
         }),
-        vbc: flags.boolean({
+        vbc: Flags.boolean({
             description: 'VBC Capabilities Enabled',
         }),
     };
@@ -125,7 +126,7 @@ export default class ApplicationsUpdate extends AppCommand<
     }
 
     async run() {
-        const flags = this.parsedFlags;
+        const flags = this.parsedFlags as UpdateFlags;
         const args = this.parsedArgs!;
         let response = args;
 
@@ -150,13 +151,13 @@ export default class ApplicationsUpdate extends AppCommand<
         if (Object.keys(flags).length > 0) {
             // merge flags into new object
             const tobeAssigned = Object.keys(flags).map(
-                (value: string, index) => {
+                (value: string) => {
                     return JSON.parse(flags[value]);
                 },
                 [],
             );
 
-            merge(newAppState.capabilities, ...tobeAssigned);
+            _.merge(newAppState.capabilities, ...tobeAssigned);
         } else {
             // run interactive
 

--- a/packages/applications/src/helpers/index.ts
+++ b/packages/applications/src/helpers/index.ts
@@ -1,6 +1,6 @@
-import { prompt } from 'prompts';
+import prompts from 'prompts';
 import { filenamifyPath } from 'filenamify';
-
+const { prompt } = prompts;
 interface WebhookQuestions {
     name: string;
     url?: string;

--- a/packages/applications/tsconfig.json
+++ b/packages/applications/tsconfig.json
@@ -1,3 +1,21 @@
 {
-    "extends": "../../tsconfig.json"
+    "extends": "../../tsconfig.json",
+    
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+    },
+
+    "exclude": [
+        "__tests__",
+        "dist"
+    ],
+
+    "references": [
+        { "path": "../utils" }
+    ],
+
+    "ts-node": {
+        "esm": true
+    }
 }

--- a/packages/cli/.npmrc
+++ b/packages/cli/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+bin-links=true
+engine-strict=true

--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -1,5 +1,5 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --loader ts-node/esm
 
-require('@oclif/command').run()
-.then(require('@oclif/command/flush'))
-.catch(require('@oclif/errors/handle'))
+const oclif = require('@oclif/core')
+
+oclif.run().then(require('@oclif/core/flush')).catch(require('@oclif/core/handle'))

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,29 +6,25 @@
     "bin": {
         "vonage": "./bin/run"
     },
-    "module": true,
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
+    "type": "module",
     "dependencies": {
-        "@oclif/command": "1.8.16",
-        "@oclif/config": "1.18.3",
-        "@oclif/core": "1.16.3",
-        "@oclif/parser": "^3.8.7",
+        "@oclif/core": "1.16.4",
+        "@oclif/plugin-help": "5.1.15",
+        "@oclif/plugin-plugins": "2.1.4",
         "@types/node": "18.7.18",
         "@types/shelljs": "0.8.11",
-        "@vonage/cli-utils": "^1.3.0",
-        "cli-ux": "5.6.3",
-        "filenamify": "^5.1.1",
+        "@vonage/cli-plugin-applications": "1.2.0",
+        "@vonage/cli-plugin-numberinsight": "1.2.0",
+        "@vonage/cli-plugin-sms": "1.2.0",
+        "@vonage/cli-plugin-users": "1.2.0",
+        "@vonage/cli-utils": "1.3.0",
         "lodash": "4.17.21",
-        "shelljs": "0.8.5"
-    },
-    "bundleDependencies": {
-        "@vonage/cli-plugin-applications": "1.1.2",
-        "@vonage/cli-plugin-numberinsight": "1.1.3",
-        "@vonage/cli-plugin-numbers": "1.1.2",
-        "@vonage/cli-plugin-users": "1.1.2"
+        "shelljs": "0.8.5",
+        "ts-node": "10.9.1"
     },
     "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
     },
     "files": [
         "/bin",
@@ -52,53 +48,19 @@
             "@vonage/cli-plugin-applications",
             "@vonage/cli-plugin-numbers",
             "@vonage/cli-plugin-numberinsight",
-            "@vonage/cli-plugin-users"
+            "@vonage/cli-plugin-users",
+            "@vonage/cli-plugin-sms",
+            "@vonage/cli-plugin-conversations"
         ],
         "hooks": {
             "init": "./dist/hooks/init"
-        },
-        "topics": {
-            "auth": {
-                "hidden": true
-            },
-            "apps": {
-                "hidden": true
-            },
-            "apps:conversations": {
-                "hidden": true
-            },
-            "apps:users": {
-                "hidden": true
-            },
-            "apps:conversations:members": {
-                "hidden": true
-            },
-            "apps:users:conversations": {
-                "hidden": true
-            },
-            "account": {
-                "hidden": true
-            },
-            "balance": {
-                "hidden": true
-            },
-            "config": {
-                "hidden": true
-            },
-            "numbers": {
-                "hidden": true
-            },
-            "plugins": {
-                "hidden": true
-            }
         }
     },
     "repository": "Vonage/vonage-cli",
     "scripts": {
-        "postpack": "rm -f oclif.manifest.json",
-        "posttest": "eslint . --ext .ts --config .eslintrc",
-        "prepack": "rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
+        "postpack": "npx shx rm -f oclif.manifest.json",
+        "prepack": "npx shx rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
         "version": "oclif-dev readme && git add README.md",
-        "build": "tsc -b"
+        "build": "npx shx rm -rf dist tsconfig.tsbuildinfo && tsc --build --verbose"
     }
 }

--- a/packages/cli/src/commands/balance/index.ts
+++ b/packages/cli/src/commands/balance/index.ts
@@ -1,8 +1,7 @@
-import BaseCommand from '@vonage/cli-utils';
+import VonageCommand from '@vonage/cli-utils';
 
-export default class DisplayBalance extends BaseCommand<
-    typeof DisplayBalance.flags
-> {
+export default class DisplayBalance
+    extends VonageCommand<typeof DisplayBalance> {
     static description = 'display your Vonage account balance';
 
     static examples = [

--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -1,13 +1,15 @@
-import BaseCommand from '@vonage/cli-utils';
-import cli from 'cli-ux';
+import VonageCommand from '@vonage/cli-utils';
+import { CliUx } from '@oclif/core';
 
-export default class ConfigList extends BaseCommand<typeof ConfigList.flags> {
+const cli = CliUx.ux;
+
+export default class ConfigList extends VonageCommand<typeof ConfigList> {
     static description = 'manage Vonage CLI configuration';
 
     static examples = [];
 
     async run() {
         this.log('~~~User Config~~~');
-        cli.log(JSON.stringify(Object.assign({}, this.userConfig)));
+        cli.log(JSON.stringify(Object.assign({}, this._userConfig)));
     }
 }

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -1,17 +1,17 @@
-import BaseCommand from '@vonage/cli-utils';
-import { flags } from '@oclif/command';
+import VonageCommand from '@vonage/cli-utils';
+import { Flags } from '@oclif/core';
 import { ArgInput } from '@oclif/core/lib/interfaces';
-import { merge } from 'lodash';
+import _ from 'lodash';
 
-export default class ConfigSet extends BaseCommand<typeof ConfigSet.flags> {
+export default class ConfigSet
+    extends VonageCommand<typeof ConfigSet> {
     static description = 'set Vonage CLI config';
 
     static flags = {
-        ...BaseCommand.flags,
-        apiKey: flags.string({
+        apiKey: Flags.string({
             description: 'Vonage API Key',
         }),
-        apiSecret: flags.string({
+        apiSecret: Flags.string({
             description: 'Vonage API Key',
         }),
     };
@@ -21,7 +21,7 @@ export default class ConfigSet extends BaseCommand<typeof ConfigSet.flags> {
     async run() {
         const flags = this.globalFlags;
         // add start, stop process indicators
-        this.saveConfig(merge({}, this.userConfig, flags));
+        this.saveConfig(_.merge({}, this._userConfig, flags));
         this.log('Configuration saved.');
     }
 }

--- a/packages/cli/src/commands/jwt/index.ts
+++ b/packages/cli/src/commands/jwt/index.ts
@@ -1,41 +1,31 @@
-import BaseCommand from '@vonage/cli-utils';
-import { flags } from '@oclif/command';
-import { OutputFlags } from '@oclif/parser';
+import VonageCommand from '@vonage/cli-utils';
+import { Flags } from '@oclif/core';
 import { readFileSync } from 'fs';
 
-interface GenerateJWTFlags {
-    app_id: any;
-    key_file: any;
-    subject?: any;
-    acl?: any;
-    exp?: any;
-}
-
-export default class GenerateJWT extends BaseCommand<typeof GenerateJWT.flags> {
+export default class GenerateJWT extends VonageCommand<typeof GenerateJWT> {
     static description = 'generate a Vonage JWT token';
 
     static examples = [
         `jwt --key_file='./testing.key' --app_id=31521081-e4c7-41fe-bccc-44af98879068`,
     ];
 
-    static flags: OutputFlags<typeof BaseCommand.flags> & GenerateJWTFlags = {
-        ...BaseCommand.flags,
-        app_id: flags.string({
+    static flags = {
+        app_id: Flags.string({
             required: true,
             description: 'Application ID to authenticate with',
         }),
-        key_file: flags.string({
+        key_file: Flags.string({
             required: true,
             description: 'Path to private key file location',
         }),
-        subject: flags.string({
+        subject: Flags.string({
             required: false,
         }),
-        acl: flags.string({
+        acl: Flags.string({
             required: false,
             description: `Read more about it in the ACL overview - https://developer.vonage.com/conversation/guides/jwt-acl#acls`,
         }),
-        exp: flags.string({
+        exp: Flags.string({
             required: false,
             description: 'Expiration of created JWT - defaults to 24 hours.',
         }),

--- a/packages/cli/src/hooks/init.ts
+++ b/packages/cli/src/hooks/init.ts
@@ -1,4 +1,4 @@
-import { Hook } from '@oclif/config';
+import { Hook } from '@oclif/core';
 import { promises as fs } from 'fs';
 import { writeFileSync, constants } from 'fs';
 import * as path from 'path';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,1 @@
-export { run } from '@oclif/command';
+export { run } from '@oclif/core';

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,3 +1,26 @@
 {
-    "extends": "../../tsconfig.json"
+    "extends": "../../tsconfig.json",
+
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist"
+    },
+
+    "references": [
+        { "path": "../applications" },
+        { "path": "../conversations" },
+        { "path": "../numbers" },
+        { "path": "../numberInsight" },
+        { "path": "../users" },
+        { "path": "../sms" }
+    ],
+
+    "exclude": [
+        "__tests__",
+        "dist"
+    ],
+
+    "ts-node": {
+        "esm": true
+    }
 }

--- a/packages/conversations/.npmrc
+++ b/packages/conversations/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+bin-links=true
+engine-strict=true

--- a/packages/conversations/bin/run
+++ b/packages/conversations/bin/run
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-
-require('@oclif/command').run()
-.catch(require('@oclif/errors/handle'))

--- a/packages/conversations/bin/run.cmd
+++ b/packages/conversations/bin/run.cmd
@@ -1,3 +1,0 @@
-@echo off
-
-node "%~dp0\run" %*

--- a/packages/conversations/package.json
+++ b/packages/conversations/package.json
@@ -5,21 +5,17 @@
     "homepage": "https://github.com/vonage/vonage-cli",
     "license": "MIT",
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
-    "module": true,
+    "type": "module",
     "dependencies": {
-        "@oclif/command": "1.8.16",
-        "@oclif/config": "1.18.3",
-        "@oclif/core": "1.16.3",
-        "@oclif/parser": "3.8.7",
-        "@vonage/cli-utils": "^1.3.0",
+        "@oclif/core": "1.19.0",
+        "@vonage/cli-utils": "1.3.0",
         "@vonage/jwt": "3.0.0-beta.1",
         "@vonage/vetch": "3.0.0-beta.3",
-        "chalk": "5.0.1",
-        "cli-ux": "5.6.3",
-        "lodash": "^4.17.21"
+        "chalk": "5.1.2",
+        "lodash": "4.17.21"
     },
     "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
     },
     "files": [
         "/dist",
@@ -36,22 +32,12 @@
         "oclif-plugin"
     ],
     "oclif": {
-        "commands": "./dist/commands",
-        "bin": "oclif-example",
-        "devPlugins": [
-            "@oclif/plugin-help"
-        ]
+        "commands": "./dist/commands"
     },
     "scripts": {
-        "postpack": "rm -f oclif.manifest.json",
-        "prepack": "rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
-        "test": "mocha \"__tests__/commands/**/*.test.ts\" -v",
-        "test-watch": "",
+        "postpack": "npx shx rm -f oclif.manifest.json",
+        "prepack": "npx shx rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
         "version": "oclif-dev readme && git add README.md",
-        "build": "tsc -b"
-    },
-    "devDependencies": {
-        "@oclif/test": "^2.1.1",
-        "nock": "^13.2.9"
+        "build": "npx shx rm -rf dist tsconfig.tsbuildinfo && tsc --build --verbose"
     }
 }

--- a/packages/conversations/src/commands/apps/conversations/create.ts
+++ b/packages/conversations/src/commands/apps/conversations/create.ts
@@ -1,6 +1,6 @@
-import { flags } from '@oclif/command';
+import { Flags } from '@oclif/core';
 import { ArgInput } from '@oclif/core/lib/interfaces';
-import ConversationCommand from '../../../conversations_base';
+import ConversationCommand from '../../../conversations_base.js';
 import chalk from 'chalk';
 
 export default class ConversationCreate extends ConversationCommand<
@@ -12,9 +12,9 @@ export default class ConversationCreate extends ConversationCommand<
 
     static flags = {
         ...ConversationCommand.flags,
-        display_name: flags.string({ description: '' }),
-        image_url: flags.string({ description: '' }),
-        ttl: flags.string({ description: '' }),
+        display_name: Flags.string({ description: '' }),
+        image_url: Flags.string({ description: '' }),
+        ttl: Flags.string({ description: '' }),
     };
 
     static args: ArgInput = [{ name: 'name', required: false }];

--- a/packages/conversations/src/commands/apps/conversations/delete.ts
+++ b/packages/conversations/src/commands/apps/conversations/delete.ts
@@ -1,5 +1,5 @@
 import { ArgInput } from '@oclif/core/lib/interfaces';
-import ConversationCommand from '../../../conversations_base';
+import ConversationCommand from '../../../conversations_base.js';
 import chalk from 'chalk';
 
 export default class ConversationDelete extends ConversationCommand<

--- a/packages/conversations/src/commands/apps/conversations/index.ts
+++ b/packages/conversations/src/commands/apps/conversations/index.ts
@@ -1,7 +1,8 @@
-import { flags } from '@oclif/command';
 import { ArgInput } from '@oclif/core/lib/interfaces';
-import ConversationCommand from '../../../conversations_base';
-import cli from 'cli-ux';
+import ConversationCommand from '../../../conversations_base.js';
+import { CliUx, Flags } from '@oclif/core';
+
+const cli = CliUx.ux;
 
 export default class ConversationDefault extends ConversationCommand<
     typeof ConversationDefault.flags
@@ -13,11 +14,11 @@ export default class ConversationDefault extends ConversationCommand<
     static flags = {
         ...ConversationCommand.flags,
         // make defaults
-        date_start: flags.string({ description: '', hidden: true }),
-        date_end: flags.string({ description: '', hidden: true }),
-        page_size: flags.string({ description: '', hidden: true }),
-        order: flags.string({ description: '', hidden: true }),
-        cursor: flags.string({ description: '', hidden: true }),
+        date_start: Flags.string({ description: '', hidden: true }),
+        date_end: Flags.string({ description: '', hidden: true }),
+        page_size: Flags.string({ description: '', hidden: true }),
+        order: Flags.string({ description: '', hidden: true }),
+        cursor: Flags.string({ description: '', hidden: true }),
     };
 
     static args: ArgInput = [];

--- a/packages/conversations/src/commands/apps/conversations/members/add.ts
+++ b/packages/conversations/src/commands/apps/conversations/members/add.ts
@@ -1,7 +1,9 @@
-import cli from 'cli-ux';
 import chalk from 'chalk';
-import ConversationCommand from '../../../../conversations_base';
+import ConversationCommand from '../../../../conversations_base.js';
 import { ArgInput } from '@oclif/core/lib/interfaces';
+import { CliUx } from '@oclif/core';
+
+const cli = CliUx.ux;
 
 export default class ConversationMemberAdd extends ConversationCommand<
     typeof ConversationMemberAdd.flags

--- a/packages/conversations/src/commands/apps/conversations/members/index.ts
+++ b/packages/conversations/src/commands/apps/conversations/members/index.ts
@@ -1,7 +1,8 @@
-import { flags } from '@oclif/command';
 import { ArgInput } from '@oclif/core/lib/interfaces';
-import ConversationCommand from '../../../../conversations_base';
-import cli from 'cli-ux';
+import ConversationCommand from '../../../../conversations_base.js';
+import { Flags, CliUx } from '@oclif/core';
+
+const cli = CliUx.ux;
 
 export default class ConversationMemberDefault extends ConversationCommand<
     typeof ConversationMemberDefault.flags
@@ -12,9 +13,9 @@ export default class ConversationMemberDefault extends ConversationCommand<
 
     static flags = {
         ...ConversationCommand.flags,
-        page_size: flags.string({ description: '', hidden: true }),
-        order: flags.string({ description: '', hidden: true }),
-        cursor: flags.string({ description: '', hidden: true }),
+        page_size: Flags.string({ description: '', hidden: true }),
+        order: Flags.string({ description: '', hidden: true }),
+        cursor: Flags.string({ description: '', hidden: true }),
     };
 
     static args: ArgInput = [{ name: 'conversationID', required: false }];

--- a/packages/conversations/src/commands/apps/conversations/members/remove.ts
+++ b/packages/conversations/src/commands/apps/conversations/members/remove.ts
@@ -1,6 +1,6 @@
 import { ArgInput } from '@oclif/core/lib/interfaces';
 import chalk from 'chalk';
-import ConversationCommand from '../../../../conversations_base';
+import ConversationCommand from '../../../../conversations_base.js';
 
 export default class ConversationMemberRemove extends ConversationCommand<
     typeof ConversationMemberRemove.flags

--- a/packages/conversations/src/commands/apps/conversations/members/show.ts
+++ b/packages/conversations/src/commands/apps/conversations/members/show.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { ArgInput } from '@oclif/core/lib/interfaces';
-import ConversationCommand from '../../../../conversations_base';
+import ConversationCommand from '../../../../conversations_base.js';
 
 export default class ConversationMemberShow extends ConversationCommand<
     typeof ConversationMemberShow.flags

--- a/packages/conversations/src/commands/apps/conversations/show.ts
+++ b/packages/conversations/src/commands/apps/conversations/show.ts
@@ -1,4 +1,4 @@
-import ConversationCommand from '../../../conversations_base';
+import ConversationCommand from '../../../conversations_base.js';
 import chalk from 'chalk';
 import { ArgInput } from '@oclif/core/lib/interfaces';
 

--- a/packages/conversations/src/commands/apps/conversations/update.ts
+++ b/packages/conversations/src/commands/apps/conversations/update.ts
@@ -1,6 +1,6 @@
-import { flags } from '@oclif/command';
+import { Flags } from '@oclif/core';
 import { ArgInput } from '@oclif/core/lib/interfaces';
-import ConversationCommand from '../../../conversations_base';
+import ConversationCommand from '../../../conversations_base.js';
 import chalk from 'chalk';
 
 export default class UserConversations extends ConversationCommand<
@@ -12,10 +12,10 @@ export default class UserConversations extends ConversationCommand<
 
     static flags = {
         ...ConversationCommand.flags,
-        name: flags.string({ description: '' }),
-        display_name: flags.string({ description: '' }),
-        image_url: flags.string({ description: '' }),
-        ttl: flags.string({ description: '' }),
+        name: Flags.string({ description: '' }),
+        display_name: Flags.string({ description: '' }),
+        image_url: Flags.string({ description: '' }),
+        ttl: Flags.string({ description: '' }),
     };
 
     static args: ArgInput = [{ name: 'conversationID', required: false }];

--- a/packages/conversations/src/commands/apps/users/conversations.ts
+++ b/packages/conversations/src/commands/apps/users/conversations.ts
@@ -1,7 +1,8 @@
-import { flags } from '@oclif/command';
-import ConversationCommand from '../../../conversations_base';
-import cli from 'cli-ux';
+import { CliUx, Flags } from '@oclif/core';
+import ConversationCommand from '../../../conversations_base.js';
 import { ArgInput } from '@oclif/core/lib/interfaces';
+
+const cli = CliUx.ux;
 
 export default class ConversationUpdate extends ConversationCommand<
     typeof ConversationUpdate.flags
@@ -12,11 +13,11 @@ export default class ConversationUpdate extends ConversationCommand<
 
     static flags = {
         ...ConversationCommand.flags,
-        date_start: flags.string({ description: '' }), // make defaults
-        date_end: flags.string({ description: '' }),
-        page_size: flags.string({ description: '' }),
-        order: flags.string({ description: '' }),
-        cursor: flags.string({ description: '' }),
+        date_start: Flags.string({ description: '' }), // make defaults
+        date_end: Flags.string({ description: '' }),
+        page_size: Flags.string({ description: '' }),
+        order: Flags.string({ description: '' }),
+        cursor: Flags.string({ description: '' }),
     };
 
     static args: ArgInput = [{ name: 'userID', required: false }];

--- a/packages/conversations/src/conversations_base.ts
+++ b/packages/conversations/src/conversations_base.ts
@@ -1,29 +1,15 @@
-import BaseCommand from '@vonage/cli-utils';
-import { OutputFlags } from '@oclif/parser';
-import { ArgInput } from '@oclif/core/lib/interfaces';
+import VonageCommand from '@vonage/cli-utils';
 import { tokenGenerate } from '@vonage/jwt';
 import { request } from '@vonage/vetch';
 import { readFileSync } from 'fs';
-import { merge } from 'lodash';
-import { HTTPMethods, ResponseTypes } from './types';
+import _ from 'lodash';
+import { HTTPMethods, ResponseTypes } from './types.js';
 
-export default abstract class ConversationsCommand<
-    T extends typeof BaseCommand.flags,
-> extends BaseCommand<T> {
+export default abstract class ConversationsCommand<T>
+    extends VonageCommand<typeof ConversationsCommand> {
     protected _token!: string;
     protected _baseurl = `https://api.nexmo.com/v0.3/conversations`;
     protected _userBaseurl = `https://api.nexmo.com/v0.3/users`;
-    protected parsedArgs
-    protected parsedFlags
-
-
-    static flags: OutputFlags<typeof BaseCommand.flags> = {
-        ...BaseCommand.flags,
-    };
-
-    static args: ArgInput = {
-        ...BaseCommand.args,
-    };
 
     protected _defaultHttpOptions = {
         method: HTTPMethods.GET,
@@ -85,7 +71,7 @@ export default abstract class ConversationsCommand<
     }
 
     async getAllConversations(params) {
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts['url'] = `${this._baseurl}`;
         opts['headers']['Authorization'] = `Bearer ${this._token}`;
         const response = await request(opts);
@@ -93,7 +79,7 @@ export default abstract class ConversationsCommand<
     }
 
     async createConversation(params) {
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts['url'] = `${this._baseurl}`;
         opts['method'] = HTTPMethods.POST;
         opts['data'] = params;
@@ -103,7 +89,7 @@ export default abstract class ConversationsCommand<
     }
 
     async getConversationById(id) {
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts['url'] = `${this._baseurl}/${id}`;
         opts['method'] = HTTPMethods.GET;
         opts['headers']['Authorization'] = `Bearer ${this._token}`;
@@ -112,7 +98,7 @@ export default abstract class ConversationsCommand<
     }
 
     async updateConversation(params) {
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts['url'] = `${this._baseurl}/${params.conversationID}`;
         opts['method'] = HTTPMethods.PUT;
         delete params.conversationID;
@@ -123,7 +109,7 @@ export default abstract class ConversationsCommand<
     }
 
     async deleteConversation(id) {
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts['url'] = `${this._baseurl}/${id}`;
         opts['method'] = HTTPMethods.DELETE;
         opts['headers']['Authorization'] = `Bearer ${this._token}`;
@@ -132,7 +118,7 @@ export default abstract class ConversationsCommand<
     }
 
     async getAllMembersInConversation(params) {
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts['url'] = `${this._baseurl}/${params.conversationID}/members`;
         opts['headers']['Authorization'] = `Bearer ${this._token}`;
         const response = await request(opts);
@@ -140,7 +126,7 @@ export default abstract class ConversationsCommand<
     }
 
     async getMemberById(params) {
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts[
             'url'
         ] = `${this._baseurl}/${params.conversationID}/members/${params.memberID}`;
@@ -161,7 +147,7 @@ export default abstract class ConversationsCommand<
             },
         };
 
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts['url'] = `${this._baseurl}/${params.conversationID}/members`;
         opts['method'] = HTTPMethods.POST;
         opts['data'] = data;
@@ -175,7 +161,7 @@ export default abstract class ConversationsCommand<
             state: 'left',
         };
 
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts[
             'url'
         ] = `${this._baseurl}/${params.conversationID}/members/${params.memberID}`;
@@ -187,7 +173,7 @@ export default abstract class ConversationsCommand<
     }
 
     async getConversationsByUser(params) {
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts['url'] = `${this._userBaseurl}/${params.userID}/conversations/`;
         opts['method'] = HTTPMethods.GET;
         opts['headers']['Authorization'] = `Bearer ${this._token}`;

--- a/packages/conversations/tsconfig.json
+++ b/packages/conversations/tsconfig.json
@@ -1,3 +1,19 @@
 {
-    "extends": "../../tsconfig.json"
+    "extends": "../../tsconfig.json",
+    
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+    },
+
+    "exclude": [
+        "__tests__",
+        "dist"
+    ],
+    "references": [
+        { "path": "../utils" }
+    ],
+    "ts-node": {
+        "esm": true
+    }
 }

--- a/packages/numberInsight/.npmrc
+++ b/packages/numberInsight/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+bin-links=true
+engine-strict=true

--- a/packages/numberInsight/bin/run
+++ b/packages/numberInsight/bin/run
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-
-require('@oclif/command').run()
-.catch(require('@oclif/errors/handle'))

--- a/packages/numberInsight/bin/run.cmd
+++ b/packages/numberInsight/bin/run.cmd
@@ -1,3 +1,0 @@
-@echo off
-
-node "%~dp0\run" %*

--- a/packages/numberInsight/package.json
+++ b/packages/numberInsight/package.json
@@ -3,18 +3,16 @@
     "version": "1.2.0",
     "author": "Vonage Dev Rel <devrel@vonage.com>",
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
-    "module": true,
+    "type": "module",
     "dependencies": {
-        "@oclif/core": "^1.16.3",
-        "@oclif/parser": "3.8.7",
-        "@vonage/cli-utils": "^1.3.0",
-        "chalk": "5.0.1",
-        "cli-ux": "5.6.3",
+        "@oclif/core": "1.19.0",
+        "@vonage/cli-utils": "1.3.0",
+        "chalk": "5.1.2",
         "lodash": "4.17.21",
-        "prompts": "^2.4.2"
+        "prompts": "2.4.2"
     },
     "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
     },
     "files": [
         "/dist",
@@ -29,20 +27,13 @@
     ],
     "license": "MIT",
     "oclif": {
-        "commands": "./dist/commands",
-        "bin": "oclif-example",
-        "devPlugins": [
-            "@oclif/plugin-help"
-        ]
+        "commands": "./dist/commands"
     },
     "repository": "Vonage/vonage-cli",
     "scripts": {
-        "postpack": "rm -f oclif.manifest.json",
-        "posttest": "eslint . --ext .ts --config .eslintrc",
-        "prepack": "rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
-        "test": "../../node_modules/.bin/jest test",
-        "test-watch": "../../node_modules/.bin/jest test --watch",
+        "postpack": "npx shx rm -f oclif.manifest.json",
+        "prepack": "npx shx rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
         "version": "oclif-dev readme && git add README.md",
-        "build": "tsc -b"
+        "build": "npx shx rm -rf dist tsconfig.tsbuildinfo && tsc --build --verbose"
     }
 }

--- a/packages/numberInsight/src/commands/numberinsight/index.ts
+++ b/packages/numberInsight/src/commands/numberinsight/index.ts
@@ -1,10 +1,13 @@
-import NumberInsightCommand from '../../numberinsight_base';
+import NumberInsightCommand from '../../numberinsight_base.js';
 import { ArgInput } from '@oclif/core/lib/interfaces';
-import { flags } from '@oclif/parser';
-import { startCase, toLower } from 'lodash';
-import { prompt } from 'prompts';
+import _ from 'lodash';
+import prompts from 'prompts';
 import chalk from 'chalk';
-import cli from 'cli-ux';
+import { CliUx, Flags } from '@oclif/core';
+
+const { prompt } = prompts;
+
+const cli = CliUx.ux;
 
 function notBasic(level) {
     return level === 'standard' || level === 'advancedSync';
@@ -22,13 +25,13 @@ export default class NumberInsight extends NumberInsightCommand<
 
     static flags = {
         ...NumberInsightCommand.flags,
-        level: flags.string({
+        level: Flags.string({
             required: false,
             default: 'basic',
-            parse: (input) => (input === 'advanced' ? `advancedSync` : input),
+            parse: async (input) => (input === 'advanced' ? `advancedSync` : input),
             options: ['basic', 'standard', 'advanced'],
         }),
-        confirm: flags.boolean({ char: 'y', required: false }),
+        confirm: Flags.boolean({ char: 'y', required: false }),
     };
 
     static args: ArgInput = [{ name: 'number', required: true }];
@@ -66,7 +69,7 @@ export default class NumberInsight extends NumberInsightCommand<
 
         this.log(
             chalk.underline.bold.inverse(
-                `Number Insights - ${startCase(toLower(flags.level))}`,
+                `Number Insights - ${_.startCase(_.toLower(flags.level))}`,
             ),
         );
         this.log();

--- a/packages/numberInsight/src/numberinsight_base.ts
+++ b/packages/numberInsight/src/numberinsight_base.ts
@@ -1,22 +1,7 @@
-import BaseCommand from '@vonage/cli-utils';
-import { OutputFlags } from '@oclif/parser';
-import { ArgInput } from '@oclif/core/lib/interfaces';
+import VonageCommand from '@vonage/cli-utils';
 
-export default abstract class NumberInsightCommand<
-    T extends typeof BaseCommand.flags,
-> extends BaseCommand<T> {
-    protected parsedArgs;
-    protected parsedFlags;
-
-    static flags: OutputFlags<typeof BaseCommand.flags> = {
-        ...BaseCommand.flags,
-        /* ... */
-    };
-
-    static args: ArgInput = {
-        ...BaseCommand.args,
-    };
-
+export default abstract class NumberInsightCommand<T>
+    extends VonageCommand<typeof NumberInsightCommand> {
     async catch(error: any) {
         return super.catch(error);
     }

--- a/packages/numberInsight/tsconfig.json
+++ b/packages/numberInsight/tsconfig.json
@@ -1,3 +1,19 @@
 {
-    "extends": "../../tsconfig.json"
+    "extends": "../../tsconfig.json",
+    
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+    },
+
+    "exclude": [
+        "__tests__",
+        "dist"
+    ],
+    "references": [
+        { "path": "../utils" }
+    ],
+    "ts-node": {
+        "esm": true
+    }
 }

--- a/packages/numbers/.npmrc
+++ b/packages/numbers/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+bin-links=true
+engine-strict=true

--- a/packages/numbers/bin/run
+++ b/packages/numbers/bin/run
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-
-require('@oclif/command').run()
-.catch(require('@oclif/errors/handle'))

--- a/packages/numbers/bin/run.cmd
+++ b/packages/numbers/bin/run.cmd
@@ -1,3 +1,0 @@
-@echo off
-
-node "%~dp0\run" %*

--- a/packages/numbers/package.json
+++ b/packages/numbers/package.json
@@ -3,17 +3,13 @@
     "version": "1.2.0",
     "author": "Vonage Dev Rel <devrel@vonage.com>",
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
-    "module": true,
+    "type": "module",
     "dependencies": {
-        "@oclif/command": "1.8.16",
-        "@oclif/config": "1.18.3",
-        "@oclif/core": "1.16.3",
-        "@oclif/parser": "3.8.7",
-        "@vonage/cli-utils": "^1.3.0",
-        "cli-ux": "5.6.3"
+        "@oclif/core": "1.19.0",
+        "@vonage/cli-utils": "1.3.0"
     },
     "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
     },
     "files": [
         "/dist",
@@ -28,25 +24,13 @@
     ],
     "license": "MIT",
     "oclif": {
-        "commands": "./dist/commands",
-        "bin": "oclif-example",
-        "devPlugins": [
-            "@oclif/plugin-help"
-        ]
+        "commands": "./dist/commands"
     },
     "repository": "Vonage/vonage-cli",
     "scripts": {
-        "postpack": "rm -f oclif.manifest.json",
-        "posttes_delete": "eslint . --ext .ts --config .eslintrc",
-        "prepack": "rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
-        "test": "mocha \"__tests__/commands/*.test.ts\"",
-        "test-watch": "../../node_modules/.bin/jest test --watch",
+        "postpack": "npx shx rm -f oclif.manifest.json",
+        "prepack": "npx shx rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
         "version": "oclif-dev readme && git add README.md",
-        "build": "tsc -b"
-    },
-    "gitHead": "e04bdc633e101ef1c1fe0190ed5d2f8452253dc4",
-    "devDependencies": {
-        "@oclif/test": "^2.1.1",
-        "nock": "^13.2.9"
+        "build": "npx shx rm -rf dist tsconfig.tsbuildinfo && tsc --build --verbose"
     }
 }

--- a/packages/numbers/src/commands/numbers/buy.ts
+++ b/packages/numbers/src/commands/numbers/buy.ts
@@ -1,4 +1,4 @@
-import NumberCommand from '../../number_base';
+import NumberCommand from '../../number_base.js';
 import { ArgInput } from '@oclif/core/lib/interfaces';
 
 export default class NumberBuy extends NumberCommand<typeof NumberBuy.flags> {

--- a/packages/numbers/src/commands/numbers/cancel.ts
+++ b/packages/numbers/src/commands/numbers/cancel.ts
@@ -1,4 +1,4 @@
-import NumberCommand from '../../number_base';
+import NumberCommand from '../../number_base.js';
 import { ArgInput } from '@oclif/core/lib/interfaces';
 
 export default class NumberCancel extends NumberCommand<

--- a/packages/numbers/src/commands/numbers/index.ts
+++ b/packages/numbers/src/commands/numbers/index.ts
@@ -1,8 +1,9 @@
-import NumberCommand from '../../number_base';
-import { OutputFlags } from '@oclif/parser';
-import { ArgInput } from '@oclif/core/lib/interfaces';
+import NumberCommand from '../../number_base.js';
+import { OutputFlags, ArgInput } from '@oclif/core/lib/interfaces';
+import { CliUx } from '@oclif/core';
 
-import cli from 'cli-ux';
+const cli = CliUx.ux;
+
 
 export default class NumberList extends NumberCommand<typeof NumberList.flags> {
     static description = 'manage your Vonage numbers';

--- a/packages/numbers/src/commands/numbers/search.ts
+++ b/packages/numbers/src/commands/numbers/search.ts
@@ -1,8 +1,8 @@
-import NumberCommand from '../../number_base';
-import { flags } from '@oclif/command';
+import NumberCommand from '../../number_base.js';
 import { ArgInput } from '@oclif/core/lib/interfaces';
+import { CliUx, Flags } from '@oclif/core';
 
-import cli from 'cli-ux';
+const cli = CliUx.ux;
 
 // TODO - INTERACTIVE MODE
 // Add in ISO look up for Country codes
@@ -22,23 +22,23 @@ export default class NumberSearch extends NumberCommand<
 
     static flags = {
         ...NumberCommand.flags,
-        type: flags.string({
+        type: Flags.string({
             description: 'Filter by type of number, such as mobile or landline',
             options: ['landline', 'mobile-lvn', 'landline-toll-free'],
         }),
-        startsWith: flags.string({
+        startsWith: Flags.string({
             description: 'Filter from the start of the phone number.',
             exclusive: ['endsWith', 'contains'],
         }),
-        endsWith: flags.string({
+        endsWith: Flags.string({
             description: 'Filter from the end of the phone number.',
             exclusive: ['startsWith', 'contains'],
         }),
-        contains: flags.string({
+        contains: Flags.string({
             description: 'Filter from anywhere in the phone number.',
             exclusive: ['endsWith', 'startsWith'],
         }),
-        features: flags.string({
+        features: Flags.string({
             description:
                 // eslint-disable-next-line max-len
                 'Available features are SMS, VOICE and MMS. To look for numbers that support multiple features, use a comma-separated value: SMS,MMS,VOICE.',

--- a/packages/numbers/src/commands/numbers/update.ts
+++ b/packages/numbers/src/commands/numbers/update.ts
@@ -1,4 +1,4 @@
-import NumberCommand from '../../number_base';
+import NumberCommand from '../../number_base.js';
 import { Flags } from '@oclif/core';
 import { ArgInput } from '@oclif/core/lib/interfaces';
 

--- a/packages/numbers/src/number_base.ts
+++ b/packages/numbers/src/number_base.ts
@@ -1,19 +1,7 @@
-import BaseCommand from '@vonage/cli-utils';
-import { ArgInput } from '@oclif/core/lib/interfaces';
-import { OutputFlags } from '@oclif/parser';
+import VonageCommand from '@vonage/cli-utils';
 
-export default abstract class NumberCommand<
-    T extends typeof BaseCommand.flags,
-> extends BaseCommand<T> {
-    static flags: OutputFlags<typeof BaseCommand.flags> = {
-        ...BaseCommand.flags,
-        /* ... */
-    };
-
-    static args: ArgInput = {
-        ...BaseCommand.args,
-    };
-
+export default abstract class NumberCommand<T>
+    extends VonageCommand<typeof NumberCommand> {
     async catch(error: any) {
         return super.catch(error);
     }

--- a/packages/numbers/tsconfig.json
+++ b/packages/numbers/tsconfig.json
@@ -1,3 +1,19 @@
 {
-    "extends": "../../tsconfig.json"
+    "extends": "../../tsconfig.json",
+    
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+    },
+
+    "exclude": [
+        "__tests__",
+        "dist"
+    ],
+    "references": [
+        { "path": "../utils" }
+    ],
+    "ts-node": {
+        "esm": true
+    }
 }

--- a/packages/sms/.npmrc
+++ b/packages/sms/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+bin-links=true
+engine-strict=true

--- a/packages/sms/bin/run
+++ b/packages/sms/bin/run
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-
-require('@oclif/command').run()
-.catch(require('@oclif/errors/handle'))

--- a/packages/sms/bin/run.cmd
+++ b/packages/sms/bin/run.cmd
@@ -1,3 +1,0 @@
-@echo off
-
-node "%~dp0\run" %*

--- a/packages/sms/package.json
+++ b/packages/sms/package.json
@@ -3,14 +3,13 @@
     "version": "1.2.0",
     "author": "Vonage Dev Rel <devrel@vonage.com>",
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
-    "module": true,
+    "type": "module",
     "dependencies": {
-        "@oclif/parser": "3.8.7",
-        "@vonage/cli-utils": "^1.3.0",
+        "@vonage/cli-utils": "1.3.0",
         "@vonage/vetch": "3.0.0-beta.3"
     },
     "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
     },
     "files": [
         "/dist",
@@ -27,24 +26,17 @@
     ],
     "license": "MIT",
     "oclif": {
-        "commands": "./dist/commands",
-        "bin": "oclif-example",
-        "devPlugins": [
-            "@oclif/plugin-help"
-        ]
+        "commands": "./dist/commands"
     },
     "repository": "Vonage/vonage-cli",
     "scripts": {
-        "postpack": "npx rimraf -f oclif.manifest.json",
-        "posttes_delete": "npx eslint . --ext .ts --config .eslintrc",
-        "prepack": "npx rimraf -rf dist && tsc -b && npx oclif-dev manifest && npx oclif-dev readme",
-        "test": "mocha \"__tests__/commands/*.test.ts\"",
-        "test-watch": "mocha \"__tests__/commands/*.test.ts\" --watch --recursive",
-        "version": "npx oclif-dev readme && git add README.md",
-        "build": "tsc -b"
+        "postpack": "npx shx rm -f oclif.manifest.json",
+        "prepack": "npx shx rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
+        "version": "oclif-dev readme && git add README.md",
+        "build": "npx shx rm -rf dist tsconfig.tsbuildinfo && tsc --build --verbose"
     },
     "devDependencies": {
-        "@oclif/test": "^2.1.1",
+        "@oclif/test": "^2.2.4",
         "nock": "^13.2.9"
     }
 }

--- a/packages/sms/src/commands/sms/index.ts
+++ b/packages/sms/src/commands/sms/index.ts
@@ -1,14 +1,8 @@
-import BaseCommand from '@vonage/cli-utils';
+import VonageCommand from '@vonage/cli-utils';
 import { request } from '@vonage/vetch';
-import { flags, OutputFlags } from '@oclif/parser';
+import { Flags } from '@oclif/core';
 
-interface SMSFlags {
-    to: any;
-    from: any;
-    message?: any;
-}
-
-export default class SMSSend extends BaseCommand<typeof SMSSend.flags> {
+export default class SMSSend extends VonageCommand<typeof SMSSend> {
     static description = 'Send a simple SMS.';
 
     static examples = [
@@ -19,15 +13,13 @@ export default class SMSSend extends BaseCommand<typeof SMSSend.flags> {
         `sms --to=15551234567 --from=15551234567 --message='Hello there!'`,
     ];
 
-    static flags: OutputFlags<typeof BaseCommand.flags> & SMSFlags = {
-        ...BaseCommand.flags,
-        to: flags.string({
+    static flags = {
+        to: Flags.string({
             required: true,
         }),
-        from: flags.string({
+        from: Flags.string({
             required: true,
-        }),
-        message: flags.string({
+        }), message: Flags.string({
             default: 'Hello from the Vonage CLI!',
         }),
     };
@@ -43,17 +35,13 @@ export default class SMSSend extends BaseCommand<typeof SMSSend.flags> {
     }
 
     async run() {
-        const flags = this.parsedFlags as OutputFlags<
-            typeof BaseCommand.flags
-        > &
-            SMSFlags;
         const response = await this.sendSMS({
             api_key: this._apiKey,
             api_secret: this._apiSecret,
-            text: flags.message,
-            ...flags,
+            text: this.flags.message,
+            ...this.flags,
         });
-        const messages = await response.data.messages
+        const messages = await response.data.messages;
 
         if (messages[0].status === '0') {
             this.log('Message sent successfully.');
@@ -62,9 +50,5 @@ export default class SMSSend extends BaseCommand<typeof SMSSend.flags> {
                 `Message failed with error: ${messages[0]['error-text']}`,
             );
         }
-    }
-
-    async catch(error: any) {
-        return super.catch(error);
     }
 }

--- a/packages/sms/tsconfig.json
+++ b/packages/sms/tsconfig.json
@@ -1,3 +1,19 @@
 {
-    "extends": "../../tsconfig.json"
+    "extends": "../../tsconfig.json",
+    
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+    },
+
+    "exclude": [
+        "__tests__",
+        "dist"
+    ],
+    "references": [
+        { "path": "../utils" }
+    ],
+    "ts-node": {
+        "esm": true
+    }
 }

--- a/packages/users/.npmrc
+++ b/packages/users/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+bin-links=true
+engine-strict=true

--- a/packages/users/bin/run
+++ b/packages/users/bin/run
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-
-require('@oclif/command').run()
-.catch(require('@oclif/errors/handle'))

--- a/packages/users/bin/run.cmd
+++ b/packages/users/bin/run.cmd
@@ -1,3 +1,0 @@
-@echo off
-
-node "%~dp0\run" %*

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -4,22 +4,18 @@
     "author": "Vonage Dev Rel <devrel@vonage.com>",
     "homepage": "https://github.com/vonage/vonage-cli",
     "license": "MIT",
-    "module": true,
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
+    "type": "module",
     "dependencies": {
-        "@oclif/command": "1.8.16",
-        "@oclif/config": "1.18.3",
-        "@oclif/core": "1.16.3",
-        "@oclif/parser": "3.8.7",
-        "@vonage/cli-utils": "^1.3.0",
+        "@oclif/core": "1.19.0",
+        "@vonage/cli-utils": "1.3.0",
         "@vonage/jwt": "3.0.0-beta.0",
         "@vonage/vetch": "3.0.0-beta.0",
-        "chalk": "5.0.1",
-        "cli-ux": "5.6.3",
+        "chalk": "5.1.2",
         "lodash": "4.17.21"
     },
     "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
     },
     "files": [
         "/dist",
@@ -36,22 +32,12 @@
         "oclif-plugin"
     ],
     "oclif": {
-        "commands": "./dist/commands",
-        "bin": "oclif-example",
-        "devPlugins": [
-            "@oclif/plugin-help"
-        ]
+        "commands": "./dist/commands"
     },
     "scripts": {
-        "postpack": "rm -f oclif.manifest.json",
-        "posttest": "eslint . --ext .ts --config .eslintrc",
-        "prepack": "rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
-        "test": "../../node_modules/.bin/jest test",
-        "test-watch": "../../node_modules/.bin/jest test --watch",
+        "postpack": "npx shx rm -f oclif.manifest.json",
+        "prepack": "npx shx rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
         "version": "oclif-dev readme && git add README.md",
-        "build": "tsc -b"
-    },
-    "devDependencies": {
-        "@oclif/test": "^2.1.1"
+        "build": "npx shx rm -rf dist tsconfig.tsbuildinfo && tsc --build --verbose"
     }
 }

--- a/packages/users/src/commands/apps/users/create.ts
+++ b/packages/users/src/commands/apps/users/create.ts
@@ -1,10 +1,10 @@
-import { OutputFlags } from '@oclif/parser';
-import { flags } from '@oclif/command';
-import { ArgInput } from '@oclif/core/lib/interfaces';
-import UserCommand from '../../../users_base';
-import cli from 'cli-ux';
+import { CliUx, Flags } from '@oclif/core';
+import { OutputFlags, ArgInput } from '@oclif/core/lib/interfaces';
+import UserCommand from '../../../users_base.js';
 import chalk from 'chalk';
-import { VetchResponse } from '../../../types';
+import { VetchResponse } from '../../../types.js';
+
+const cli = CliUx.ux;
 
 interface CreateFlags {
     display_name: any;
@@ -18,8 +18,8 @@ export default class UsersCreate extends UserCommand<typeof UsersCreate.flags> {
 
     static flags: OutputFlags<typeof UserCommand.flags> & CreateFlags = {
         ...UserCommand.flags,
-        display_name: flags.string({ description: '' }),
-        image_url: flags.string({ description: '' }),
+        display_name: Flags.string({ description: '' }),
+        image_url: Flags.string({ description: '' }),
     };
 
     static args: ArgInput = [{ name: 'name', required: false }];

--- a/packages/users/src/commands/apps/users/delete.ts
+++ b/packages/users/src/commands/apps/users/delete.ts
@@ -1,7 +1,6 @@
-import { OutputFlags } from '@oclif/parser';
-import UserCommand from '../../../users_base';
+import UserCommand from '../../../users_base.js';
 import chalk from 'chalk';
-import { ArgInput } from '@oclif/core/lib/interfaces';
+import { OutputFlags, ArgInput } from '@oclif/core/lib/interfaces';
 
 export default class UsersDelete extends UserCommand<typeof UsersDelete.flags> {
     static description = '';

--- a/packages/users/src/commands/apps/users/index.ts
+++ b/packages/users/src/commands/apps/users/index.ts
@@ -1,8 +1,9 @@
-import { OutputFlags } from '@oclif/parser';
-import { flags } from '@oclif/command';
-import UserCommand from '../../../users_base';
-import cli from 'cli-ux';
-import { VetchResponse } from '../../../types';
+import { OutputFlags } from '@oclif/core/lib/interfaces';
+import { CliUx, Flags } from '@oclif/core';
+import UserCommand from '../../../users_base.js';
+import { VetchResponse } from '../../../types.js';
+
+const cli = CliUx.ux;
 
 interface IndexFlags {
     page_size: any;
@@ -19,9 +20,9 @@ export default class UsersDefault extends UserCommand<
 
     static flags: OutputFlags<typeof UserCommand.flags> & IndexFlags = {
         ...UserCommand.flags,
-        page_size: flags.string({ description: '', hidden: true }),
-        order: flags.string({ description: '', hidden: true }),
-        cursor: flags.string({ description: '', hidden: true }),
+        page_size: Flags.string({ description: '', hidden: true }),
+        order: Flags.string({ description: '', hidden: true }),
+        cursor: Flags.string({ description: '', hidden: true }),
     };
 
     async run() {

--- a/packages/users/src/commands/apps/users/show.ts
+++ b/packages/users/src/commands/apps/users/show.ts
@@ -1,8 +1,7 @@
-import { OutputFlags } from '@oclif/parser';
-import UserCommand from '../../../users_base';
+import UserCommand from '../../../users_base.js';
 import chalk from 'chalk';
-import { VetchResponse } from '../../../types';
-import { ArgInput } from '@oclif/core/lib/interfaces';
+import { VetchResponse } from '../../../types.js';
+import { ArgInput, OutputFlags } from '@oclif/core/lib/interfaces';
 
 export default class UsersShow extends UserCommand<typeof UsersShow.flags> {
     static description = '';

--- a/packages/users/src/commands/apps/users/update.ts
+++ b/packages/users/src/commands/apps/users/update.ts
@@ -1,9 +1,8 @@
-import { OutputFlags } from '@oclif/parser';
-import { flags } from '@oclif/command';
-import UserCommand from '../../../users_base';
+import { Flags } from '@oclif/core';
+import UserCommand from '../../../users_base.js';
 import chalk from 'chalk';
-import { VetchResponse } from '../../../types';
-import { ArgInput } from '@oclif/core/lib/interfaces';
+import { VetchResponse } from '../../../types.js';
+import { ArgInput, OutputFlags } from '@oclif/core/lib/interfaces';
 
 interface UpdateFlags {
     name: any;
@@ -18,9 +17,9 @@ export default class UsersUpdate extends UserCommand<typeof UsersUpdate.flags> {
 
     static flags: OutputFlags<typeof UserCommand.flags> & UpdateFlags = {
         ...UserCommand.flags,
-        name: flags.string({ description: '' }),
-        display_name: flags.string({ description: '' }),
-        image_url: flags.string({ description: '' }),
+        name: Flags.string({ description: '' }),
+        display_name: Flags.string({ description: '' }),
+        image_url: Flags.string({ description: '' }),
     };
 
     static args: ArgInput = [{ name: 'userID', required: false }];

--- a/packages/users/src/users_base.ts
+++ b/packages/users/src/users_base.ts
@@ -1,27 +1,16 @@
-import BaseCommand from '@vonage/cli-utils';
-import { OutputFlags } from '@oclif/parser';
-import { ArgInput } from '@oclif/core/lib/interfaces';
 import { tokenGenerate } from '@vonage/jwt';
 import { request } from '@vonage/vetch';
 import { readFileSync } from 'fs';
-import { merge } from 'lodash';
-import { HTTPMethods, ResponseTypes } from './types';
+import _ from 'lodash';
+import { HTTPMethods, ResponseTypes } from './types.js';
+import VonageCommand from '@vonage/cli-utils';
 
-export default abstract class UsersCommand<
-    T extends typeof BaseCommand.flags,
-> extends BaseCommand<T> {
+export default abstract class UsersCommand<T>
+    extends VonageCommand<typeof UsersCommand> {
     protected _token!: string;
     protected _baseurl = `https://api.nexmo.com/v0.3/users`;
     protected parsedArgs;
     protected parsedFlags;
-
-    static flags: OutputFlags<typeof BaseCommand.flags> = {
-        ...BaseCommand.flags,
-    };
-
-    static args: ArgInput = {
-        ...BaseCommand.args,
-    };
 
     protected _defaultHttpOptions = {
         method: HTTPMethods.GET,
@@ -50,7 +39,7 @@ export default abstract class UsersCommand<
     }
 
     async getAllUsers(params) {
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts['url'] = `${this._baseurl}`;
         opts['headers']['Authorization'] = `Bearer ${this._token}`;
         const response = await request(opts);
@@ -58,7 +47,7 @@ export default abstract class UsersCommand<
     }
 
     async getUserById(id) {
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts['url'] = `${this._baseurl}/${id}`;
         opts['headers']['Authorization'] = `Bearer ${this._token}`;
         const response = await request(opts);
@@ -66,7 +55,7 @@ export default abstract class UsersCommand<
     }
 
     async createUser(params) {
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts['url'] = `${this._baseurl}`;
         opts['method'] = HTTPMethods.POST;
         opts['data'] = params;
@@ -76,7 +65,7 @@ export default abstract class UsersCommand<
     }
 
     async updateUser(params) {
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts['url'] = `${this._baseurl}/${params.userID}`;
         opts['method'] = HTTPMethods.PATCH;
         opts['data'] = params;
@@ -86,7 +75,7 @@ export default abstract class UsersCommand<
     }
 
     async deleteUser(id) {
-        const opts = merge({}, this._defaultHttpOptions);
+        const opts = _.merge({}, this._defaultHttpOptions);
         opts['url'] = `${this._baseurl}/${id}`;
         opts['method'] = HTTPMethods.DELETE;
         opts['headers']['Authorization'] = `Bearer ${this._token}`;

--- a/packages/users/tsconfig.json
+++ b/packages/users/tsconfig.json
@@ -1,3 +1,19 @@
 {
-    "extends": "../../tsconfig.json"
+    "extends": "../../tsconfig.json",
+    
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+    },
+
+    "exclude": [
+        "__tests__",
+        "dist"
+    ],
+    "references": [
+        { "path": "../utils" }
+    ],
+    "ts-node": {
+        "esm": true
+    }
 }

--- a/packages/utils/.npmrc
+++ b/packages/utils/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+bin-links=true
+engine-strict=true

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,16 +3,14 @@
     "version": "1.3.0",
     "author": "Kelly Andrews @kellyjandrews",
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
-    "module": true,
+    "type": "module",
     "dependencies": {
-        "@oclif/command": "1.8.16",
-        "@oclif/config": "1.18.3",
-        "@oclif/core": "1.16.3",
-        "@types/node": "18.7.18",
+        "@oclif/core": "1.19.0",
+        "@types/node": "18.11.0",
         "@vonage/server-sdk": "2.11.2"
     },
     "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
     },
     "files": [
         "/dist",
@@ -26,11 +24,9 @@
     "license": "MIT",
     "repository": "Vonage/vonage-cli",
     "scripts": {
-        "postpack": "rm -f oclif.manifest.json",
-        "posttest": "eslint . --ext .ts --config .eslintrc",
-        "prepack": "rm -rf dist && tsc -b",
-        "test": "../../node_modules/.bin/jest test",
-        "test-watch": "../../node_modules/.bin/jest test --watch",
-        "build": "tsc -b"
+        "postpack": "npx shx rm -f oclif.manifest.json",
+        "prepack": "npx shx rm -rf dist && tsc -b && oclif-dev manifest && oclif-dev readme",
+        "version": "oclif-dev readme && git add README.md",
+        "build": "npx shx rm -rf dist tsconfig.tsbuildinfo && tsc --build --verbose"
     }
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,20 +1,17 @@
 {
     "extends": "../../tsconfig.json",
-
+    
     "compilerOptions": {
-        "composite": true,
         "rootDir": "src",
         "outDir": "dist",
-        "noEmit": false
-
     },
-
-    "includes": [
-        "src/**/*"
-    ],
 
     "exclude": [
         "__tests__",
         "dist"
-    ]
+    ],
+
+    "ts-node": {
+        "esm": true
+    }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,19 +8,21 @@
 
         "strict": false,
         "target": "ES2021",
-        "module": "commonjs",
+        "module": "ES2020",
         "moduleResolution": "node",
         "esModuleInterop": true,
         "skipLibCheck": true,
         "allowJs": true,
         "pretty": true,
+        "preserveSymlinks": true,
 
         "noImplicitAny": false,
         "noUnusedLocals": true,
         "importHelpers": true,
 
         "declaration": true,
-        "noEmit": true,
+        "composite": true,
+        "noEmit": false,
         "baseUrl": ".",
         "paths": {
             "@vonage/*": [
@@ -35,8 +37,12 @@
 
     "exclude": [
         "./dist",
-        "__tests__",
+        "**/__tests__",
         "node_modules",
         "**/*.test.*"
-    ]
+    ],
+
+    "ts-node": {
+        "esm": true
+    }
 }


### PR DESCRIPTION
Update the latest `@oclif/core` package to allow for later node support. Restored removing `dist` and `tsconfig.tsbuildinfo` in the build step since now all projects are composite projects (for them to build in the correct order). Addressed other TS errors 