### PR TITLE
fix: cli shebang for windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13241,7 +13241,7 @@
         },
         "packages/cli": {
             "name": "@vonage/cli",
-            "version": "1.2.2",
+            "version": "1.2.3-0",
             "license": "Apache 2.0",
             "dependencies": {
                 "@oclif/core": "1.20.4",

--- a/packages/applications/package.json
+++ b/packages/applications/package.json
@@ -7,13 +7,13 @@
     "types": "dist/index.d.ts",
     "type": "module",
     "dependencies": {
-        "@oclif/core": "1.20.4",
-        "@vonage/cli-utils": "1.3.0",
-        "chalk": "5.1.2",
-        "filenamify": "5.1.1",
-        "lodash": "4.17.21",
-        "prompts": "2.4.2",
-        "unique-names-generator": "4.7.1"
+        "@oclif/core": "^1.20.4",
+        "@vonage/cli-utils": "^1.3.0",
+        "chalk": "^5.1.2",
+        "filenamify": "^5.1.1",
+        "lodash": "^4.17.21",
+        "prompts": "^2.4.2",
+        "unique-names-generator": "^4.7.1"
     },
     "files": [
         "bin",

--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env NODE_NO_WARNINGS=1 node 
+#!/usr/bin/env node 
 
 const oclif = require('@oclif/core')
 

--- a/packages/cli/bin/run.cjs
+++ b/packages/cli/bin/run.cjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S NODE_NO_WARNINGS=1 node 
+#!/usr/bin/env node 
 
 const oclif = require('@oclif/core')
 

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@vonage/cli",
-    "version": "1.2.2",
+    "version": "1.2.3-0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,19 +9,20 @@
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
     "type": "module",
     "dependencies": {
-        "@oclif/core": "1.20.4",
-        "@oclif/plugin-help": "5.1.19",
-        "@oclif/plugin-plugins": "2.1.7",
-        "@types/node": "18.11.11",
-        "@types/shelljs": "0.8.11",
-        "@vonage/cli-plugin-applications": "1.2.0",
-        "@vonage/cli-plugin-numberinsight": "1.2.0",
-        "@vonage/cli-plugin-sms": "1.2.0",
-        "@vonage/cli-plugin-users": "1.2.0",
-        "@vonage/cli-utils": "1.3.0",
-        "lodash": "4.17.21",
-        "shelljs": "0.8.5",
-        "ts-node": "10.9.1"
+        "@oclif/core": "^1.20.4",
+        "@oclif/plugin-help": "^5.1.19",
+        "@oclif/plugin-plugins": "^2.1.7",
+        "@types/node": "^18.11.11",
+        "@types/shelljs": "^0.8.11",
+        "@vonage/cli-plugin-applications": "^1.2.0",
+        "@vonage/cli-plugin-conversations": "^1.0.1",
+        "@vonage/cli-plugin-numberinsight": "^1.2.0",
+        "@vonage/cli-plugin-numbers": "^1.2.2",
+        "@vonage/cli-plugin-sms": "^1.2.0",
+        "@vonage/cli-plugin-users": "^1.2.0",
+        "@vonage/cli-utils": "^1.3.0",
+        "lodash": "^4.17.21",
+        "shelljs": "^0.8.5"
     },
     "engines": {
         "node": ">=14.0.0"

--- a/packages/conversations/package.json
+++ b/packages/conversations/package.json
@@ -7,12 +7,12 @@
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
     "type": "module",
     "dependencies": {
-        "@oclif/core": "1.20.4",
-        "@vonage/cli-utils": "1.3.0",
-        "@vonage/jwt": "3.0.0-beta.1",
-        "@vonage/vetch": "3.0.0-beta.3",
-        "chalk": "5.1.2",
-        "lodash": "4.17.21"
+        "@oclif/core": "^1.20.4",
+        "@vonage/cli-utils": "^1.3.0",
+        "@vonage/jwt": "^1.0",
+        "@vonage/vetch": "^1.0",
+        "chalk": "^5.1.2",
+        "lodash": "^4.17.21"
     },
     "engines": {
         "node": ">=14.0.0"

--- a/packages/numberInsight/package.json
+++ b/packages/numberInsight/package.json
@@ -5,11 +5,11 @@
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
     "type": "module",
     "dependencies": {
-        "@oclif/core": "1.20.4",
-        "@vonage/cli-utils": "1.3.0",
-        "chalk": "5.1.2",
-        "lodash": "4.17.21",
-        "prompts": "2.4.2"
+        "@oclif/core": "^1.20.4",
+        "@vonage/cli-utils": "^1.3.0",
+        "chalk": "^5.1.2",
+        "lodash": "^4.17.21",
+        "prompts": "^2.4.2"
     },
     "engines": {
         "node": ">=14.0.0"

--- a/packages/numbers/package.json
+++ b/packages/numbers/package.json
@@ -5,8 +5,8 @@
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
     "type": "module",
     "dependencies": {
-        "@oclif/core": "1.20.4",
-        "@vonage/cli-utils": "1.3.0"
+        "@oclif/core": "^1.20.4",
+        "@vonage/cli-utils": "^1.3.0"
     },
     "engines": {
         "node": ">=14.0.0"

--- a/packages/sms/package.json
+++ b/packages/sms/package.json
@@ -6,8 +6,8 @@
     "type": "module",
     "dependencies": {
         "@oclif/core": "^1.20.4",
-        "@vonage/cli-utils": "1.3.0",
-        "@vonage/vetch": "3.0.0-beta.3"
+        "@vonage/cli-utils": "^1.3.0",
+        "@vonage/vetch": "^1.0"
     },
     "engines": {
         "node": ">=14.0.0"

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -7,12 +7,12 @@
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
     "type": "module",
     "dependencies": {
-        "@oclif/core": "1.20.4",
-        "@vonage/cli-utils": "1.3.0",
-        "@vonage/jwt": "3.0.0-beta.0",
-        "@vonage/vetch": "3.0.0-beta.0",
-        "chalk": "5.1.2",
-        "lodash": "4.17.21"
+        "@oclif/core": "^1.20.4",
+        "@vonage/cli-utils": "^1.3.0",
+        "@vonage/jwt": "^1.0",
+        "@vonage/vetch": "^1.0",
+        "chalk": "^5.1.2",
+        "lodash": "^4.17.21"
     },
     "engines": {
         "node": ">=14.0.0"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,9 +5,9 @@
     "bugs": "https://github.com/Vonage/vonage-cli/issues",
     "type": "module",
     "dependencies": {
-        "@oclif/core": "1.20.4",
-        "@types/node": "18.11.11",
-        "@vonage/server-sdk": "2.11.2"
+        "@oclif/core": "^1.20.4",
+        "@types/node": "^18.11.11",
+        "@vonage/server-sdk": "^2.11.2"
     },
     "engines": {
         "node": ">=14.0.0"


### PR DESCRIPTION
Removed the `-S NODE_NO_WARNINGS=1` from the shebang. This was causing issues with the way npm would build the shell / PowerShell scripts on windows when compiling. It looks like NPM is not that smart enough to know how to parse the shebang 