### PR TITLE
Fix validation error

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,6 @@
         "packages/*"
     ],
     "version": "independent",
-    "useWorkspaces": true,
     "publishConfig": {
         "directory": "dist"
     },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@vonage/cli",
+    "name": "@vonage/cli-monorepo",
     "homepage": "https://github.com/Vonage/vonage-cli#readme",
     "license": "Apache 2.0",
     "workspaces": [

--- a/packages/applications/src/commands/apps/create.ts
+++ b/packages/applications/src/commands/apps/create.ts
@@ -268,157 +268,162 @@ export default class ApplicationsCreate
             response.privacy = improveAi;
         }
 
-        cli.action.start(chalk.bold('Creating Application'), 'Initializing', {
-            stdout: true,
-        });
+        try {
+            cli.action.start(chalk.bold('Creating Application'), 'Initializing', {
+                stdout: true,
+            });
 
-        // create application
-        const output = await this.createApplication(response);
+            // create application
+            const output = await this.createApplication(response);
 
-        const keyFileName = sanitizeFileName(output.name);
+            const keyFileName = sanitizeFileName(output.name);
 
-        // write vonage.app file
-        const vonageAppFilePath = `${process.cwd()}/vonage_app.json`;
-        const vonagePrivateKeyFilePath = `${process.cwd()}/${keyFileName.toLowerCase()}.key`;
+            // write vonage.app file
+            const vonageAppFilePath = `${process.cwd()}/vonage_app.json`;
+            const vonagePrivateKeyFilePath = `${process.cwd()}/${keyFileName.toLowerCase()}.key`;
 
-        writeFileSync(
-            vonageAppFilePath,
-            JSON.stringify(
-                {
-                    application_name: output.name,
-                    application_id: output.id,
-                    private_key: output.keys.private_key,
-                },
-                null,
-                2,
-            ),
-        );
-
-        writeFileSync(vonagePrivateKeyFilePath, output.keys.private_key);
-
-        cli.action.stop();
-
-        const indent = '  ';
-
-        this.log(
-            chalk.magenta.underline.bold('Application Name:'),
-            output.name,
-        );
-        this.log('');
-        this.log(chalk.magenta.underline.bold('Application ID:'), output.id);
-        this.log('');
-
-        const { voice, messages, rtc, vbc } = output.capabilities;
-
-        if (voice) {
-            this.log(chalk.magenta.underline.bold('Voice Settings'));
-
-            this.log(indent, chalk.cyan.underline.bold('Event Webhook:'));
-            this.log(
-                indent,
-                indent,
-                chalk.bold('Address:'),
-                _.get(voice, 'webhooks.event_url.address'),
-            );
-            this.log(
-                indent,
-                indent,
-                chalk.bold('HTTP Method:'),
-                _.get(voice, 'webhooks.event_url.http_method'),
+            writeFileSync(
+                vonageAppFilePath,
+                JSON.stringify(
+                    {
+                        application_name: output.name,
+                        application_id: output.id,
+                        private_key: output.keys.private_key,
+                    },
+                    null,
+                    2,
+                ),
             );
 
-            this.log(indent, chalk.cyan.underline.bold('Answer Webhook:'));
+            writeFileSync(vonagePrivateKeyFilePath, output.keys.private_key);
+
+            cli.action.stop();
+
+            const indent = '  ';
+
             this.log(
-                indent,
-                indent,
-                chalk.bold('Address:'),
-                _.get(voice, 'webhooks.answer_url.address'),
-            );
-            this.log(
-                indent,
-                indent,
-                chalk.bold('HTTP Method:'),
-                _.get(voice, 'webhooks.answer_url.http_method'),
+                chalk.magenta.underline.bold('Application Name:'),
+                output.name,
             );
             this.log('');
-        }
-
-        if (messages) {
-            this.log(chalk.magenta.underline.bold('Messages Settings'));
-
-            this.log(indent, chalk.cyan.underline.bold('Inbound Webhook:'));
-            this.log(
-                indent,
-                indent,
-                chalk.bold('Address:'),
-                _.get(messages, 'webhooks.inbound_url.address'),
-            );
-            this.log(
-                indent,
-                indent,
-                chalk.bold('HTTP Method:'),
-                _.get(messages, 'webhooks.inbound_url.http_method'),
-            );
-
-            this.log(indent, chalk.cyan.underline.bold('Status Webhook:'));
-            this.log(
-                indent,
-                indent,
-                chalk.bold('Address:'),
-                _.get(messages, 'webhooks.status_url.address'),
-            );
-            this.log(
-                indent,
-                indent,
-                chalk.bold('HTTP Method:'),
-                _.get(messages, 'webhooks.status_url.http_method'),
-            );
+            this.log(chalk.magenta.underline.bold('Application ID:'), output.id);
             this.log('');
-        }
 
-        if (rtc) {
-            this.log(chalk.magenta.underline.bold('RTC Settings'));
+            const { voice, messages, rtc, vbc } = output.capabilities;
 
-            this.log(indent, chalk.cyan.underline.bold('Event Webhook:'));
-            this.log(
-                indent,
-                indent,
-                chalk.bold('Address:'),
-                _.get(rtc, 'webhooks.event_url.address'),
-            );
-            this.log(
-                indent,
-                indent,
-                chalk.bold('HTTP Method:'),
-                _.get(rtc, 'webhooks.event_url.http_method'),
-            );
+            if (voice) {
+                this.log(chalk.magenta.underline.bold('Voice Settings'));
+
+                this.log(indent, chalk.cyan.underline.bold('Event Webhook:'));
+                this.log(
+                    indent,
+                    indent,
+                    chalk.bold('Address:'),
+                    _.get(voice, 'webhooks.event_url.address'),
+                );
+                this.log(
+                    indent,
+                    indent,
+                    chalk.bold('HTTP Method:'),
+                    _.get(voice, 'webhooks.event_url.http_method'),
+                );
+
+                this.log(indent, chalk.cyan.underline.bold('Answer Webhook:'));
+                this.log(
+                    indent,
+                    indent,
+                    chalk.bold('Address:'),
+                    _.get(voice, 'webhooks.answer_url.address'),
+                );
+                this.log(
+                    indent,
+                    indent,
+                    chalk.bold('HTTP Method:'),
+                    _.get(voice, 'webhooks.answer_url.http_method'),
+                );
+                this.log('');
+            }
+
+            if (messages) {
+                this.log(chalk.magenta.underline.bold('Messages Settings'));
+
+                this.log(indent, chalk.cyan.underline.bold('Inbound Webhook:'));
+                this.log(
+                    indent,
+                    indent,
+                    chalk.bold('Address:'),
+                    _.get(messages, 'webhooks.inbound_url.address'),
+                );
+                this.log(
+                    indent,
+                    indent,
+                    chalk.bold('HTTP Method:'),
+                    _.get(messages, 'webhooks.inbound_url.http_method'),
+                );
+
+                this.log(indent, chalk.cyan.underline.bold('Status Webhook:'));
+                this.log(
+                    indent,
+                    indent,
+                    chalk.bold('Address:'),
+                    _.get(messages, 'webhooks.status_url.address'),
+                );
+                this.log(
+                    indent,
+                    indent,
+                    chalk.bold('HTTP Method:'),
+                    _.get(messages, 'webhooks.status_url.http_method'),
+                );
+                this.log('');
+            }
+
+            if (rtc) {
+                this.log(chalk.magenta.underline.bold('RTC Settings'));
+
+                this.log(indent, chalk.cyan.underline.bold('Event Webhook:'));
+                this.log(
+                    indent,
+                    indent,
+                    chalk.bold('Address:'),
+                    _.get(rtc, 'webhooks.event_url.address'),
+                );
+                this.log(
+                    indent,
+                    indent,
+                    chalk.bold('HTTP Method:'),
+                    _.get(rtc, 'webhooks.event_url.http_method'),
+                );
+                this.log('');
+            }
+
+            if (vbc) {
+                this.log(chalk.magenta.underline.bold('VBC Settings'));
+                this.log(chalk.bold('Enabled'));
+                this.log('');
+            }
+
+            this.log(chalk.magenta.underline.bold('Public Key'));
+            this.log(output.keys.public_key);
             this.log('');
-        }
 
-        if (vbc) {
-            this.log(chalk.magenta.underline.bold('VBC Settings'));
-            this.log(chalk.bold('Enabled'));
+            this.log(chalk.magenta.underline.bold('App Files'));
+            this.log(chalk.bold('Vonage App File:'), vonageAppFilePath);
             this.log('');
+            this.log(chalk.bold('Private Key File:'), vonagePrivateKeyFilePath);
+            this.log('');
+
+            this.log(
+                chalk.magenta.underline.bold('Improve AI:'),
+                output.privacy.improve_ai,
+            );
+
+            this.log('');
+
+            this.exit();
+        } catch (error) {
+            this.log(chalk.red.bold('Error creating application'));
+            this.log(chalk.red.bold(error.message));
         }
-
-        this.log(chalk.magenta.underline.bold('Public Key'));
-        this.log(output.keys.public_key);
-        this.log('');
-
-        this.log(chalk.magenta.underline.bold('App Files'));
-        this.log(chalk.bold('Vonage App File:'), vonageAppFilePath);
-        this.log('');
-        this.log(chalk.bold('Private Key File:'), vonagePrivateKeyFilePath);
-        this.log('');
-
-        this.log(
-            chalk.magenta.underline.bold('Improve AI:'),
-            output.privacy.improve_ai,
-        );
-
-        this.log('');
-
-        this.exit();
     }
 
     async catch(error: any) {

--- a/packages/applications/src/commands/apps/create.ts
+++ b/packages/applications/src/commands/apps/create.ts
@@ -261,7 +261,7 @@ export default class ApplicationsCreate
 
             const improveAi = await prompt({
                 type: 'confirm',
-                name: 'improveAi',
+                name: 'improve_ai',
                 message: `Allow use of data for AI training? Read data collection disclosure - ${kbArticle}`,
             });
 

--- a/packages/cli/src/commands/jwt/index.ts
+++ b/packages/cli/src/commands/jwt/index.ts
@@ -25,7 +25,7 @@ export default class GenerateJWT extends VonageCommand<typeof GenerateJWT> {
             required: false,
             description: `Read more about it in the ACL overview - https://developer.vonage.com/conversation/guides/jwt-acl#acls`,
         }),
-        exp: Flags.string({
+        exp: Flags.integer({
             required: false,
             description: 'Expiration of created JWT - defaults to 24 hours.',
         }),

--- a/packages/numbers/src/number_base.ts
+++ b/packages/numbers/src/number_base.ts
@@ -2,10 +2,6 @@ import VonageCommand from '@vonage/cli-utils';
 
 export default abstract class NumberCommand<T>
     extends VonageCommand<typeof NumberCommand> {
-    async catch(error: any) {
-        return super.catch(error);
-    }
-
     protected _parseParams(params): any {
         const searchResponse = {};
         if (params.startsWith) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This addresses an issue whereby parsing flags with options is too verbose. For example: 
`vonage  numbers:search US --features=VOICE,SMS` fails because it should be `SMS,VOICE`. The version of `oclif` will not catch the error in the args parser and will display the stack trace. Here, we are intercepting the parse error and are just reporting the message as expected.

Updating oclif is not ideal as it will cause double work compared with`2.x` work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.