### PR TITLE
fix: stop leaking cursor-show escape sequence into command output

### DIFF
--- a/__tests__/commands/jwt/jwt.create.test.js
+++ b/__tests__/commands/jwt/jwt.create.test.js
@@ -3,6 +3,15 @@ import { handler, jwtFlags } from '../../../src/commands/jwt/create.js';
 import { mockConsole } from '../../helpers.js';
 import { getTestMiddlewareArgs, testPrivateKey } from '../../common.js';
 import jwt from 'jsonwebtoken';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliBin = path.join(__dirname, '../../../bin/vonage.js');
+const testPrivateKeyFile = path.join(__dirname, '../../test.private.key');
 
 describe('Command: vonage jwt create', () => {
   beforeEach(() => {
@@ -83,5 +92,33 @@ describe('Command: vonage jwt create', () => {
     expect(jwtFlags.acl.coerce).toBeDefined();
     expect(() => jwtFlags.acl.coerce('invalid')).toThrow('Failed to parse JSON for ACL');
     expect(() => jwtFlags.acl.coerce('{"foo": "bar"}')).toThrow('ACL Failed to validate against schema');
+  });
+
+  describe('CLI output', () => {
+    let homeDir;
+
+    beforeEach(() => {
+      homeDir = mkdtempSync(path.join(tmpdir(), 'vonage-cli-test-'));
+    });
+
+    afterEach(() => {
+      rmSync(homeDir, { recursive: true, force: true });
+    });
+
+    test('should not print a trailing cursor-show escape sequence (\u001B[?25h) to stdout', () => {
+      const stdout = execFileSync(
+        process.execPath,
+        [
+          cliBin,
+          'jwt',
+          'create',
+          '--app-id', '00000000-0000-0000-0000-000000000000',
+          '--private-key', testPrivateKeyFile,
+        ],
+        { env: { ...process.env, HOME: homeDir } },
+      ).toString();
+
+      expect(stdout).not.toContain('\u001B[?25h');
+    });
   });
 });

--- a/__tests__/ux/cursor.test.js
+++ b/__tests__/ux/cursor.test.js
@@ -1,0 +1,47 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { hideCursor, resetCursor } from '../../src/ux/cursor.js';
+
+describe('Utils: cursor', () => {
+  let stdoutSpy;
+  let stderrSpy;
+
+  beforeEach(() => {
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  test('resetCursor writes nothing when the cursor was never hidden', () => {
+    resetCursor();
+
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  test('resetCursor shows the cursor after hideCursor was called', () => {
+    hideCursor();
+    stdoutSpy.mockClear();
+    stderrSpy.mockClear();
+
+    resetCursor();
+
+    expect(stdoutSpy).toHaveBeenCalledWith('\u001B[?25h');
+    expect(stderrSpy).toHaveBeenCalledWith('\u001B[?25h');
+  });
+
+  test('resetCursor is a no-op the second time it is called in a row', () => {
+    hideCursor();
+    resetCursor();
+    stdoutSpy.mockClear();
+    stderrSpy.mockClear();
+
+    resetCursor();
+
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/coerceJSON.js
+++ b/src/utils/coerceJSON.js
@@ -1,4 +1,4 @@
-import Ajv from 'ajv/dist/2020';
+import Ajv from 'ajv/dist/2020.js';
 const ajv = new Ajv();
 
 const coerceJSON = (argName, schema) => (json) => {

--- a/src/ux/cursor.js
+++ b/src/ux/cursor.js
@@ -1,9 +1,17 @@
+let isHidden = false;
+
 const resetCursor = () => {
+  if (!isHidden) {
+    return;
+  }
+
+  isHidden = false;
   process.stderr.write('\u001B[?25h');
   process.stdout.write('\u001B[?25h');
 };
 
 const hideCursor = () => {
+  isHidden = true;
   process.stderr.write('\u001B[?25l');
   process.stdout.write('\u001B[?25l');
 };


### PR DESCRIPTION
## Summary

- `resetCursor()` in `src/ux/cursor.js` always wrote the cursor-show escape
  sequence (`\x1b[?25h`) on process exit, even when `hideCursor()` had never
  been called (e.g. `jwt create`).
  This happened because `src/ux/cursor.js` is loaded for every command via
  yargs' `commandDir`, which registers a process-wide `exit` handler
  regardless of which command actually runs. The stray control sequence
  polluted captured or piped output, for example:
  `TOKEN=$(vonage jwt create ...)`.
  Fixed by tracking whether the cursor had actually been hidden and making
  `resetCursor()` a no-op otherwise.

- Fixed an unrelated Node ESM resolution issue in
  `src/utils/coerceJSON.js` (`ajv/dist/2020` →
  `ajv/dist/2020.js`), which caused `ERR_MODULE_NOT_FOUND` under strict ESM
  resolution and prevented `jwt create` and `jwt validate` from running via
  the CLI binary.

- Added unit and integration tests:
  - unit tests for `src/ux/cursor.js`
  - a CLI integration test that spawns the real binary and verifies that
    `jwt create` never emits the trailing escape sequence.

## Test plan
- [x] `npm test` — 49 suites / 432 tests passing
- [x] `npx eslint` — clean
- [x] Manually verified `node bin/vonage.js jwt create --app-id ... --private-key ...`
      no longer emits `\x1b[?25h`
- [x] Confirmed the new tests fail against the pre-fix code and pass after
      the fix (regression check)
